### PR TITLE
Apply origin/main diff: pin HF revisions to main

### DIFF
--- a/cosmos_framework/inference/args.py
+++ b/cosmos_framework/inference/args.py
@@ -857,7 +857,7 @@ _CHECKPOINTS: dict[str, CheckpointConfig] = {
         s3_uri="s3://bucket1/cosmos3_vfm/cosmos3_ga_midtraining/cosmos3_ga_16bm8b_v2_midtrain/checkpoints/iter_000006000/",
         hf=CheckpointDirHf(
             repository="nvidia/Cosmos3-Nano",
-            revision="a18b727665f0dd03bc032229a6acb47ba11dc4cb",
+            revision="main",
         ),
     ),
     "Cosmos3-Super": CheckpointConfig(
@@ -866,7 +866,7 @@ _CHECKPOINTS: dict[str, CheckpointConfig] = {
         s3_uri="s3://bucket1/cosmos3_vfm/cosmos3_ga_midtraining/cosmos3_ga_64bm32b_v3_midtrain/checkpoints/iter_000001800/",
         hf=CheckpointDirHf(
             repository="nvidia/Cosmos3-Super",
-            revision="6121c7c697d255d3dfd226a64d4fd5f576037edb",
+            revision="main",
         ),
     ),
 }

--- a/cosmos_framework/inference/common/checkpoints.py
+++ b/cosmos_framework/inference/common/checkpoints.py
@@ -246,7 +246,7 @@ def register_checkpoints():
             ),
             hf=CheckpointDirHf(
                 repository="nvidia/Cosmos3-Nano",
-                revision="a18b727665f0dd03bc032229a6acb47ba11dc4cb",
+                revision="main",
                 subdirectory="sound_tokenizer",
             ),
             # The sound_tokenizer/ safetensors are decoder-only and use the diffusers

--- a/cosmos_framework/inference/configs/model/Cosmos3-Nano.yaml
+++ b/cosmos_framework/inference/configs/model/Cosmos3-Nano.yaml
@@ -182,5 +182,5 @@ model:
       tokenizer:
         _target_: cosmos3._src.vfm.processors.build_processor_lazy
         repository: nvidia/Cosmos3-Nano
-        revision: a18b727665f0dd03bc032229a6acb47ba11dc4cb
+        revision: main
       use_system_prompt: false

--- a/cosmos_framework/inference/configs/model/Cosmos3-Super.yaml
+++ b/cosmos_framework/inference/configs/model/Cosmos3-Super.yaml
@@ -182,5 +182,5 @@ model:
       tokenizer:
         _target_: cosmos3._src.vfm.processors.build_processor_lazy
         repository: nvidia/Cosmos3-Super
-        revision: 6121c7c697d255d3dfd226a64d4fd5f576037edb
+        revision: main
       use_system_prompt: false

--- a/cosmos_framework/scripts/action_policy_server_robolab.py
+++ b/cosmos_framework/scripts/action_policy_server_robolab.py
@@ -73,7 +73,7 @@ _CONCAT_VIEW_DESCRIPTION = (
     "The bottom row contains two horizontally concatenated third-person perspective views of the scene from opposite "
     "sides, with the robot visible."
 )
-_DEFAULT_HF_REVISION = "3e936098b920eba3462070865a49ec5422ca9489"
+_DEFAULT_HF_REVISION = "main"
 _ROBOLAB_POLICY_HF_REPOSITORIES = {
     "Cosmos3-Nano-Policy-DROID": "nvidia/Cosmos3-Nano-Policy-DROID",
     "nvidia/Cosmos3-Nano-Policy-DROID": "nvidia/Cosmos3-Nano-Policy-DROID",


### PR DESCRIPTION
Brings the 5 files that diverged between this HEAD and origin/main in line with origin/main, changing pinned HF commit revisions to "main".