### PR TITLE
fix: add pynvml fallback for unified memory architectures (e.g., GB10)

### DIFF
--- a/cosmos_framework/inference/args.py
+++ b/cosmos_framework/inference/args.py
@@ -1046,8 +1046,16 @@ def _get_dp_shard_size(
 
 @cache
 def _get_device_memory_bytes() -> int:
-    pynvml.nvmlInit()
-    handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-    info = pynvml.nvmlDeviceGetMemoryInfo(handle)
-    pynvml.nvmlShutdown()
-    return info.total
+    try:
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        pynvml.nvmlShutdown()
+        return info.total
+    except Exception:
+        # Fallback for unified memory architectures (e.g., GB10) where
+        # nvmlDeviceGetMemoryInfo is not supported.
+        import torch
+        if torch.cuda.is_available():
+            return int(torch.cuda.get_device_properties(0).total_memory)
+        return 128 * 1024**3  # Default 128GB


### PR DESCRIPTION
On unified memory architectures like NVIDIA GB10 (DGX Spark), pynvml.nvmlDeviceGetMemoryInfo() raises NVMLError_NotSupported because there is no dedicated GPU memory.

This change wraps the pynvml call in a try/except and falls back to torch.cuda.get_device_properties().total_memory when pynvml fails. If CUDA is also unavailable, defaults to 128GB.

Co-authored-by: Claude