### PR TITLE
fix: add ci test download cache with refined retry mechanism

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -121,10 +121,7 @@ jobs:
 
       # One inference call over t2vs (+sound), action policy, and forward_dynamics; checks each output.
       # MAX_GPUS defaults to 8. -s streams the live process log.
-      # COSMOS_DOWNLOAD_CACHE_DIR: action/forward_dynamics download GitHub-raw
-      # input assets; cache them in the same persistent dir as the unittest job
-      # (under $RUNNER_WORKSPACE, outside the repo tree) so both jobs -- and runs
-      # across PRs on this runner -- reuse one warm cache. See the unittest job.
+      # Reuse the same input-asset cache dir as the unittest job.
       - name: Nano inference smoke (t2vs + action policy + forward_dynamics, 8 GPU)
         run: |
           export LD_LIBRARY_PATH=
@@ -198,12 +195,8 @@ jobs:
       # is absent (via RunIf / pytest.skip guards), so this is green without
       # internal credentials; provide the credential file on the runner to
       # exercise them. New tests are picked up automatically (no markers/lists).
-      # COSMOS_DOWNLOAD_CACHE_DIR caches the downloaded input assets (e.g. the
-      # GitHub-raw test inputs) in a persistent, URL-keyed dir under
-      # $RUNNER_WORKSPACE -- outside the repo tree, so the cleanup step below
-      # doesn't wipe it. Reused across runs, so the flaky GitHub-raw 504s are hit
-      # at most once per asset (the in-code backoff retry is the cold-cache
-      # fallback). Safe because the asset URLs are commit-pinned (.../raw/<sha>/).
+      # Cache downloaded input assets in a persistent dir (outside the repo tree,
+      # so the cleanup step keeps it) and reuse it across runs.
       - name: Unit tests
         run: |
           export LD_LIBRARY_PATH=

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -121,9 +121,14 @@ jobs:
 
       # One inference call over t2vs (+sound), action policy, and forward_dynamics; checks each output.
       # MAX_GPUS defaults to 8. -s streams the live process log.
+      # COSMOS_DOWNLOAD_CACHE_DIR: action/forward_dynamics download GitHub-raw
+      # input assets; cache them in the same persistent dir as the unittest job
+      # (under $RUNNER_WORKSPACE, outside the repo tree) so both jobs -- and runs
+      # across PRs on this runner -- reuse one warm cache. See the unittest job.
       - name: Nano inference smoke (t2vs + action policy + forward_dynamics, 8 GPU)
         run: |
           export LD_LIBRARY_PATH=
+          export COSMOS_DOWNLOAD_CACHE_DIR="$RUNNER_WORKSPACE/cosmos_input_cache"
           uv run --all-extras --group=cu128-train python -m pytest -v -s \
             tests/nano_inference_smoke_test.py --num-gpus=8 --levels=2 -o addopts=
 

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -193,9 +193,16 @@ jobs:
       # is absent (via RunIf / pytest.skip guards), so this is green without
       # internal credentials; provide the credential file on the runner to
       # exercise them. New tests are picked up automatically (no markers/lists).
+      # COSMOS_DOWNLOAD_CACHE_DIR caches the downloaded input assets (e.g. the
+      # GitHub-raw test inputs) in a persistent, URL-keyed dir under
+      # $RUNNER_WORKSPACE -- outside the repo tree, so the cleanup step below
+      # doesn't wipe it. Reused across runs, so the flaky GitHub-raw 504s are hit
+      # at most once per asset (the in-code backoff retry is the cold-cache
+      # fallback). Safe because the asset URLs are commit-pinned (.../raw/<sha>/).
       - name: Unit tests
         run: |
           export LD_LIBRARY_PATH=
+          export COSMOS_DOWNLOAD_CACHE_DIR="$RUNNER_WORKSPACE/cosmos_input_cache"
           uv run --all-extras --group=cu128-train python -m pytest -v -s \
             cosmos_framework/ -o addopts=
 

--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import glob
+import hashlib
 import itertools
 import json
 import os
@@ -132,6 +133,38 @@ def _download_file_hf(url: str, path: Path):
             f.write(chunk)
 
 
+def _resolve_url_download(url: str, name: str) -> Path:
+    """Fetch ``url`` to a local file and return its path.
+
+    When ``COSMOS_DOWNLOAD_CACHE_DIR`` is set, downloads are cached there keyed by
+    URL and reused across runs — the input-asset URLs are pinned to a content
+    commit (``.../raw/<sha>/...``), so the URL fully identifies the bytes. This
+    lets CI skip re-fetching the flaky GitHub-raw assets on every run (the retry
+    in ``_download_file_url`` becomes the cold-cache fallback). When unset, the
+    legacy behavior is used: a throwaway temp directory per download.
+    """
+    cache_root = os.environ.get("COSMOS_DOWNLOAD_CACHE_DIR")
+    if not cache_root:
+        local_path = Path(tempfile.mkdtemp()) / name
+        _download_file_url(url, local_path)
+        return local_path
+
+    cache_dir = Path(cache_root)
+    digest = hashlib.sha256(url.encode()).hexdigest()[:16]
+    cache_path = cache_dir / f"{digest}-{name}"
+    done_marker = Path(f"{cache_path}.done")
+    if cache_path.exists() and done_marker.exists():
+        return cache_path
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    # Download to a unique temp file in the cache dir, then atomically move it
+    # into place so concurrent workers/ranks never observe a half-written file.
+    tmp_path = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.tmp")
+    _download_file_url(url, tmp_path)
+    os.replace(tmp_path, cache_path)
+    done_marker.write_text(url)
+    return cache_path
+
+
 def _download_file(url: str, path: Path):
     if "://" not in url and Path(url).resolve() == path.resolve():
         return
@@ -141,10 +174,9 @@ def _download_file(url: str, path: Path):
             return
 
     if "://" in url:
-        # Download to a temporary directory and symlink to the final path.
-        # This keeps the output directory small.
-        local_path = Path(tempfile.TemporaryDirectory(delete=False).name) / path.name
-        _download_file_url(url, local_path)
+        # Download (optionally via the persistent cache) and symlink to the final
+        # path. This keeps the output directory small.
+        local_path = _resolve_url_download(url, path.name)
     else:
         local_path = Path(url)
 

--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -55,17 +55,12 @@ VIDEO_EXTENSIONS = [".mp4"]
 MEDIA_EXTENSIONS = IMAGE_EXTENSIONS + VIDEO_EXTENSIONS
 
 
-# Network downloads (e.g. the GitHub-raw input assets) intermittently return
-# transient gateway errors (502/503/504). obstore retries internally but only
-# within a short (~15s) window, so wrap each download in an outer retry with
-# exponential backoff + jitter. All three are env-overridable so CI can tune them
-# without a code change.
+# Retry transient download errors with exponential backoff (env-overridable).
 _DOWNLOAD_MAX_ATTEMPTS = int(os.environ.get("COSMOS_DOWNLOAD_MAX_ATTEMPTS", "6"))
 _DOWNLOAD_BACKOFF_BASE_S = float(os.environ.get("COSMOS_DOWNLOAD_BACKOFF_S", "4"))
 _DOWNLOAD_BACKOFF_CAP_S = float(os.environ.get("COSMOS_DOWNLOAD_BACKOFF_CAP_S", "60"))
 
-# HTTP statuses that won't be fixed by retrying — fail fast instead of burning
-# the whole backoff budget on a permanent error.
+# Statuses not worth retrying.
 _PERMANENT_HTTP_MARKERS = ("400 Bad Request", "401 Unauthorized", "403 Forbidden", "404 Not Found")
 
 
@@ -85,12 +80,12 @@ def _download_file_url(url: str, path: Path):
         try:
             _download_file_url_once(url, path)
             return
-        except Exception as exc:  # noqa: BLE001 — classify below; reraise if permanent/exhausted
+        except Exception as exc:  # noqa: BLE001
             last_exc = exc
             if _is_permanent_download_error(exc) or attempt == _DOWNLOAD_MAX_ATTEMPTS:
                 break
             delay = min(_DOWNLOAD_BACKOFF_CAP_S, _DOWNLOAD_BACKOFF_BASE_S * 2 ** (attempt - 1))
-            delay += random.uniform(0, delay * 0.25)  # jitter to de-correlate concurrent jobs
+            delay += random.uniform(0, delay * 0.25)  # jitter
             log.warning(
                 f"Download attempt {attempt}/{_DOWNLOAD_MAX_ATTEMPTS} for {url} failed "
                 f"({type(exc).__name__}: {exc}); retrying in {delay:.1f}s."
@@ -136,12 +131,8 @@ def _download_file_hf(url: str, path: Path):
 def _resolve_url_download(url: str, name: str) -> Path:
     """Fetch ``url`` to a local file and return its path.
 
-    When ``COSMOS_DOWNLOAD_CACHE_DIR`` is set, downloads are cached there keyed by
-    URL and reused across runs — the input-asset URLs are pinned to a content
-    commit (``.../raw/<sha>/...``), so the URL fully identifies the bytes. This
-    lets CI skip re-fetching the flaky GitHub-raw assets on every run (the retry
-    in ``_download_file_url`` becomes the cold-cache fallback). When unset, the
-    legacy behavior is used: a throwaway temp directory per download.
+    When ``COSMOS_DOWNLOAD_CACHE_DIR`` is set, downloads are cached there by URL
+    and reused across runs; otherwise a fresh temp dir is used per download.
     """
     cache_root = os.environ.get("COSMOS_DOWNLOAD_CACHE_DIR")
     if not cache_root:
@@ -156,8 +147,7 @@ def _resolve_url_download(url: str, name: str) -> Path:
     if cache_path.exists() and done_marker.exists():
         return cache_path
     cache_dir.mkdir(parents=True, exist_ok=True)
-    # Download to a unique temp file in the cache dir, then atomically move it
-    # into place so concurrent workers/ranks never observe a half-written file.
+    # Atomic move so concurrent writers never observe a half-written file.
     tmp_path = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.tmp")
     _download_file_url(url, tmp_path)
     os.replace(tmp_path, cache_path)

--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -6,8 +6,10 @@ import glob
 import itertools
 import json
 import os
+import random
 import re
 import tempfile
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
@@ -52,7 +54,52 @@ VIDEO_EXTENSIONS = [".mp4"]
 MEDIA_EXTENSIONS = IMAGE_EXTENSIONS + VIDEO_EXTENSIONS
 
 
+# Network downloads (e.g. the GitHub-raw input assets) intermittently return
+# transient gateway errors (502/503/504). obstore retries internally but only
+# within a short (~15s) window, so wrap each download in an outer retry with
+# exponential backoff + jitter. All three are env-overridable so CI can tune them
+# without a code change.
+_DOWNLOAD_MAX_ATTEMPTS = int(os.environ.get("COSMOS_DOWNLOAD_MAX_ATTEMPTS", "6"))
+_DOWNLOAD_BACKOFF_BASE_S = float(os.environ.get("COSMOS_DOWNLOAD_BACKOFF_S", "4"))
+_DOWNLOAD_BACKOFF_CAP_S = float(os.environ.get("COSMOS_DOWNLOAD_BACKOFF_CAP_S", "60"))
+
+# HTTP statuses that won't be fixed by retrying — fail fast instead of burning
+# the whole backoff budget on a permanent error.
+_PERMANENT_HTTP_MARKERS = ("400 Bad Request", "401 Unauthorized", "403 Forbidden", "404 Not Found")
+
+
+def _is_permanent_download_error(exc: BaseException) -> bool:
+    if type(exc).__name__ in {"NotFoundError", "PermissionError"}:
+        return True
+    msg = str(exc)
+    return any(marker in msg for marker in _PERMANENT_HTTP_MARKERS)
+
+
 def _download_file_url(url: str, path: Path):
+    """Download ``url`` to ``path``, retrying transient network/server errors."""
+    from cosmos_framework.utils import log
+
+    last_exc: BaseException | None = None
+    for attempt in range(1, _DOWNLOAD_MAX_ATTEMPTS + 1):
+        try:
+            _download_file_url_once(url, path)
+            return
+        except Exception as exc:  # noqa: BLE001 — classify below; reraise if permanent/exhausted
+            last_exc = exc
+            if _is_permanent_download_error(exc) or attempt == _DOWNLOAD_MAX_ATTEMPTS:
+                break
+            delay = min(_DOWNLOAD_BACKOFF_CAP_S, _DOWNLOAD_BACKOFF_BASE_S * 2 ** (attempt - 1))
+            delay += random.uniform(0, delay * 0.25)  # jitter to de-correlate concurrent jobs
+            log.warning(
+                f"Download attempt {attempt}/{_DOWNLOAD_MAX_ATTEMPTS} for {url} failed "
+                f"({type(exc).__name__}: {exc}); retrying in {delay:.1f}s."
+            )
+            time.sleep(delay)
+
+    raise RuntimeError(f"Failed to download {url} after {_DOWNLOAD_MAX_ATTEMPTS} attempt(s)") from last_exc
+
+
+def _download_file_url_once(url: str, path: Path):
     if "huggingface.co" in url:
         _download_file_hf(url, path)
     else:

--- a/cosmos_framework/inference/common/args_test.py
+++ b/cosmos_framework/inference/common/args_test.py
@@ -16,10 +16,7 @@ CHECKPOINTS: dict[str, CheckpointConfig] = {
 
 
 def test_download_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    # This test covers the download/symlink/meta mechanics, which assume each
-    # download is independent (e.g. force-re-download lands at a fresh path). The
-    # opt-in cache (COSMOS_DOWNLOAD_CACHE_DIR, set in CI) dedups by URL and would
-    # break that assumption, so disable it here.
+    # Disable the URL cache; this test asserts each download is independent.
     monkeypatch.delenv("COSMOS_DOWNLOAD_CACHE_DIR", raising=False)
 
     download_url_1 = (

--- a/cosmos_framework/inference/common/args_test.py
+++ b/cosmos_framework/inference/common/args_test.py
@@ -5,6 +5,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from cosmos_framework.inference.args import DEFAULT_CHECKPOINT, DEFAULT_CHECKPOINT_NAME
 from cosmos_framework.inference.common.args import CheckpointConfig, CheckpointOverrides, download_file
 
@@ -13,7 +15,13 @@ CHECKPOINTS: dict[str, CheckpointConfig] = {
 }
 
 
-def test_download_file(tmp_path: Path):
+def test_download_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # This test covers the download/symlink/meta mechanics, which assume each
+    # download is independent (e.g. force-re-download lands at a fresh path). The
+    # opt-in cache (COSMOS_DOWNLOAD_CACHE_DIR, set in CI) dedups by URL and would
+    # break that assumption, so disable it here.
+    monkeypatch.delenv("COSMOS_DOWNLOAD_CACHE_DIR", raising=False)
+
     download_url_1 = (
         "https://github.com/nvidia-cosmos/cosmos-dependencies/raw/2b17a2413bd86b2cf9b03823637108851e4ddf2d/inputs/vision/robot_153.jpg"
     )


### PR DESCRIPTION
### Summary                                                                                                                                                    
  CI tests download input assets (e.g. action/video inputs) over the network, and these intermittently fail with transient gateway errors (502/503/504), flaking 
  the run. This PR makes those downloads robust and avoids re-fetching the same assets every run.                                                                
                                                                                                                                                                 
  ### Changes                                                                                                                                                    
  - **Backoff retry** (`inference/common/args.py`): wrap each input download in an outer retry with exponential backoff + jitter (6 attempts, env-overridable via
  `COSMOS_DOWNLOAD_*`). Permanent errors (400/401/403/404) fail fast.                                                                                            
  - **Opt-in download cache**: when `COSMOS_DOWNLOAD_CACHE_DIR` is set, downloads are cached by URL and reused across runs; unset → unchanged behavior.
  Concurrent writers use an atomic move.                                                                                                                         
  - **CI wiring** (`gpu-tests.yml`): the `unittest` and `inference-smoke` jobs point at a shared persistent cache dir (`$RUNNER_WORKSPACE/cosmos_input_cache`,   
  outside the repo tree so cleanup keeps it), reused across runs and PRs on the same runner.
                                                                                                                                                                 
  ### Impact                                                                                                                                                     
  - Production/local behavior unchanged: cache is off unless the env var is set; retry is transparent on success and only adds resilience on failure.            
  - Only new persisted artifact is the cache dir; replaces previously-leaked `/tmp` temp dirs in those jobs. 