### PR TITLE
Make T2I and T2V compatible with `transformers>=5.0.0`.

### DIFF
--- a/cosmos_framework/model/vfm/mot/unified_mot.py
+++ b/cosmos_framework/model/vfm/mot/unified_mot.py
@@ -691,7 +691,7 @@ def _impl_init(
     ``Nemotron3DenseVLTextModel``.  Sub-layer classes (MLP, RMSNorm,
     rotary embedding) are dispatched through ``layer_types``.
     """
-    self.padding_idx = config.pad_token_id
+    self.padding_idx = getattr(config, "pad_token_id", None)
     self.vocab_size = config.vocab_size
 
     self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)

--- a/cosmos_framework/model/vfm/vlm/qwen3_vl/qwen3_vl.py
+++ b/cosmos_framework/model/vfm/vlm/qwen3_vl/qwen3_vl.py
@@ -320,7 +320,11 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        rope_type = self.rope_type
+        if rope_type not in ROPE_INIT_FUNCTIONS and rope_type == "default":
+            # transformers>=5 renamed "default" RoPE entry to "proportional".
+            rope_type = "proportional"
+        self.rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
 
         self.mrope_section = (
             config.rope_scaling.get("mrope_section", [24, 20, 20]) if config.rope_scaling is not None else [24, 20, 20]


### PR DESCRIPTION
Hi Cosmos team,

We are fixing some CVE issues found in `transformers<=5.0.0`. This PR makes minor updates so the codebase works seamlessly with both pinned `4.57.6` and `>=5.0.0` for T2I and T2V.
