### PR TITLE
Fix join_path type inconsistency: return Path when Path inputs are provided

### DIFF
--- a/cosmos_framework/utils/easy_io/backends/base_backend.py
+++ b/cosmos_framework/utils/easy_io/backends/base_backend.py
@@ -70,7 +70,7 @@ class BaseStorageBackend(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> str:
+    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> Union[str, Path]:
         pass
 
     @abstractmethod

--- a/cosmos_framework/utils/easy_io/backends/boto3_backend.py
+++ b/cosmos_framework/utils/easy_io/backends/boto3_backend.py
@@ -284,7 +284,7 @@ class Boto3Backend(BaseStorageBackend):
         self,
         filepath: Union[str, Path],
         *filepaths: Union[str, Path],
-    ) -> str:
+    ) -> Union[str, Path]:
         r"""Concatenate all file paths.
 
         Join one or more filepath components intelligently. The return value
@@ -294,7 +294,7 @@ class Boto3Backend(BaseStorageBackend):
             filepath (str or Path): Path to be concatenated.
 
         Returns:
-            str: The result after concatenation.
+            str or Path: The result after concatenation.
 
         Examples:
             >>> backend = Boto3Backend()

--- a/cosmos_framework/utils/easy_io/backends/http_backend.py
+++ b/cosmos_framework/utils/easy_io/backends/http_backend.py
@@ -112,7 +112,7 @@ class HTTPBackend(BaseStorageBackend):
     def isfile(self, filepath: Union[str, Path]) -> bool:
         raise NotImplementedError(f"isfile not supported in {self.name}")
 
-    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> str:
+    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> Union[str, Path]:
         raise NotImplementedError(f"join_path not supported in {self.name}")
 
     @contextmanager

--- a/cosmos_framework/utils/easy_io/backends/local_backend.py
+++ b/cosmos_framework/utils/easy_io/backends/local_backend.py
@@ -187,7 +187,7 @@ class LocalBackend(BaseStorageBackend):
         """
         return osp.isfile(filepath)
 
-    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> str:
+    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> Union[str, Path]:
         r"""Concatenate all file paths.
 
         Join one or more filepath components intelligently. The return value
@@ -197,7 +197,7 @@ class LocalBackend(BaseStorageBackend):
             filepath (str or Path): Path to be concatenated.
 
         Returns:
-            str: The result of concatenation.
+            str or Path: The result of concatenation. Returns a Path if any input is a Path.
 
         Examples:
             >>> backend = LocalBackend()
@@ -207,8 +207,10 @@ class LocalBackend(BaseStorageBackend):
             >>> backend.join_path(filepath1, filepath2, filepath3)
             '/path/of/dir/dir2/path/of/file'
         """
-        # TODO, if filepath or filepaths are Path, should return Path
-        return osp.join(filepath, *filepaths)
+        result = osp.join(filepath, *filepaths)
+        if isinstance(filepath, Path) or any(isinstance(p, Path) for p in filepaths):
+            return Path(result)
+        return result
 
     @contextmanager
     def get_local_path(

--- a/cosmos_framework/utils/easy_io/backends/msc_backend.py
+++ b/cosmos_framework/utils/easy_io/backends/msc_backend.py
@@ -554,7 +554,7 @@ class MSCBackend(BaseStorageBackend):
         self,
         filepath: Union[str, Path],
         *filepaths: Union[str, Path],
-    ) -> str:
+    ) -> Union[str, Path]:
         r"""Concatenate all file paths.
 
         Join one or more filepath components intelligently. The return value
@@ -564,7 +564,7 @@ class MSCBackend(BaseStorageBackend):
             filepath (str or Path): Path to be concatenated.
 
         Returns:
-            str: The result after concatenation.
+            str or Path: The result after concatenation.
 
         Examples:
             >>> backend = MSCBackend()

--- a/cosmos_framework/utils/easy_io/easy_io.py
+++ b/cosmos_framework/utils/easy_io/easy_io.py
@@ -424,7 +424,7 @@ def join_path(
         backend_key (str, optional): The key to get the backend from register.
 
     Returns:
-        str: The result of concatenation.
+        str or Path: The result of concatenation. Returns a Path if any input is a Path.
 
     Examples:
         >>> filepath1 = '/path/of/dir1'

--- a/cosmos_framework/utils/easy_io/file_client.py
+++ b/cosmos_framework/utils/easy_io/file_client.py
@@ -375,7 +375,7 @@ class FileClient:
         """
         return self.client.isfile(filepath)
 
-    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> str:
+    def join_path(self, filepath: Union[str, Path], *filepaths: Union[str, Path]) -> Union[str, Path]:
         r"""Concatenate all file paths.
 
         Join one or more filepath components intelligently. The return value
@@ -385,7 +385,7 @@ class FileClient:
             filepath (str or Path): Path to be concatenated.
 
         Returns:
-            str: The result of concatenation.
+            str or Path: The result of concatenation. Returns a Path if any input is a Path.
         """
         return self.client.join_path(filepath, *filepaths)
 


### PR DESCRIPTION
## Summary

`LocalBackend.join_path` accepted `Union[str, Path]` inputs but always returned `str` (via `os.path.join`), even when `Path` objects were passed. This violated the type contract and could cause `AttributeError` downstream.

## Changes

- **local_backend.py**: Now checks if any input is a `Path` and returns `Path(result)` accordingly. Removed the stale TODO that acknowledged this issue.
- **base_backend.py, easy_io.py, file_client.py**: Updated return type from `str` to `Union[str, Path]`.
- **boto3_backend.py, msc_backend.py, http_backend.py**: Updated return type signature for consistency with the abstract base class.

## Related Issue

Closes #32