### PR TITLE
Fix multi-control transfer: honor control weights under torch.compile

### DIFF
--- a/cosmos_framework/model/generator/mot/attention.py
+++ b/cosmos_framework/model/generator/mot/attention.py
@@ -336,6 +336,14 @@ def multi_control_two_way_attention(
 
     n_text = int(causal_k_offsets[-1])
     n_full = int(full_q_offsets[-1])
+    # `n_full` comes from int(full_q_offsets[-1]) → an unbacked symint under
+    # torch.compile. The control ranges + noisy range partition the full/gen
+    # segment with noisy last, so `noisy_e` (a concrete int from SplitInfo) is
+    # exactly the number of valid gen tokens == n_full. Binding them lets Dynamo
+    # treat the per-segment `full_*_v[cs:ce]` slices below as concrete-length, so
+    # the in-place writes `full_out_v[cs:ce] = _sdpa(...)` don't raise
+    # data-dependent `Eq(slice_len, out_len)` guards.
+    torch._check(n_full == noisy_e)
 
     # Unpad to avoid padded rows entering the softmax denominator.
     causal_k_v = causal_k[:n_text]  # [N_text, Hkv, D]
@@ -350,15 +358,38 @@ def multi_control_two_way_attention(
 
     def _sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
         """Maskless attention using cosmos_framework.model.attention() → [N_q, Hq*D]."""
+        # K and V are built by concatenating the SAME [text | ctrl_i | noisy]
+        # slices, so their sequence lengths are always equal. Under
+        # torch.compile (fullgraph=True) those lengths are unbacked symints
+        # (from data-dependent unpadding), and the attention frontend's
+        # `if key_shape[1] != value_shape[1]` guard (attention/checks.py) cannot
+        # be resolved symbolically. Assert the invariant so Dynamo can discharge
+        # the guard statically instead of raising a data-dependent error.
+        torch._check(k.shape[0] == v.shape[0])
         n_q, n_kv = q.shape[0], k.shape[0]
-        seqlens_q = torch.tensor([n_q], dtype=torch.int32, device=q.device)
-        seqlens_kv = torch.tensor([n_kv], dtype=torch.int32, device=k.device)
+        # These lengths come from data-dependent unpadding, so they are unbacked
+        # symints under torch.compile. The selected attention backend (NATTEN)
+        # validates varlen inputs with `max_seqlen == 0` / `max_seqlen < 1`
+        # guards; without a positivity fact Dynamo cannot discharge `Eq(n, 0)`.
+        # Every control/noisy segment always has at least one token, so assert it.
+        torch._check(n_q > 0)
+        torch._check(n_kv > 0)
+        # Pass cumulative_seqlen_{Q,KV} + max_seqlen_{Q,KV} directly instead of
+        # seqlens_{Q,KV}. The frontend derives cumulative offsets from seqlens via
+        # `generate_varlen_parameters`, which calls `.max().item()` (a device-host
+        # sync) and is explicitly disallowed inside a torch.compile region. Each
+        # pass here is a single (batch=1) packed sequence, so the cumulative
+        # offsets are simply [0, n]. Building them ourselves keeps the whole path
+        # inside the compiled graph.
+        zero = torch.zeros(1, dtype=torch.int32, device=q.device)
+        cu_seqlens_q = torch.cat([zero, torch.tensor([n_q], dtype=torch.int32, device=q.device)])
+        cu_seqlens_kv = torch.cat([zero, torch.tensor([n_kv], dtype=torch.int32, device=q.device)])
         res = attention(
             q.unsqueeze(0),  # [1, N_q,  Hq,  D]
             k.unsqueeze(0),  # [1, N_kv, Hkv, D]
             v.unsqueeze(0),  # [1, N_kv, Hkv, D]
-            seqlens_Q=seqlens_q,
-            seqlens_KV=seqlens_kv,
+            cumulative_seqlen_Q=cu_seqlens_q,
+            cumulative_seqlen_KV=cu_seqlens_kv,
             max_seqlen_Q=n_q,
             max_seqlen_KV=n_kv,
         )  # [1, N_q, Hq, D]

--- a/cosmos_framework/model/generator/omni_mot_model.py
+++ b/cosmos_framework/model/generator/omni_mot_model.py
@@ -1915,6 +1915,11 @@ class OmniMoTModel(ImaginaireModel):
             x0_tokens_sound=noise_x_sound if has_sound else None,
             fps_sound=gen_data_clean.fps_sound if has_sound else None,
             num_vision_items_per_sample=num_items,
+            # Multi-control transfer: carry per-control weights so the packer can
+            # populate vision_item_split_lens / control_weights on the packed
+            # sequence. Without this, multi_control_two_way_attention never runs
+            # and all controls are blended equally (weights ignored).
+            control_weights=gen_data_clean.control_weights,
         )
 
         packed_sequence = self._pack_input_sequence(


### PR DESCRIPTION
## Summary

Multi-control transfer inference silently ignored per-control weights.

## Changes

- **`omni_mot_model.py`**: propagate `control_weights` into `gen_data_for_packing` 
- **`attention.py`**: make `multi_control_two_way_attention` `torch.compile`-safe. Its per-segment lengths come from data-dependent unpadding (unbacked symints), which tripped several Dynamo guards under `fullgraph=True`:
  - `torch._check(k.shape[0] == v.shape[0])` — frontend K/V-length guard
  - `torch._check(n_q > 0)` / `torch._check(n_kv > 0)` — NATTEN `max_seqlen == 0` / `< 1` varlen guards
  - `torch._check(n_full == noisy_e)` — makes per-segment `[cs:ce]` slices concrete-length, fixing the in-place write shape guard
  - pass `cumulative_seqlen_{Q,KV}` + `max_seqlen_{Q,KV}` instead of `seqlens_{Q,KV}` to avoid the disallowed `generate_varlen_parameters` device-host sync inside the compiled region

## Test plan

- [x] PAI-Bench-C multi_control eval runs end-to-end under compiled attention (previously crashed with data-dependent Dynamo guard errors).
- [x] Diagnostics confirm `control_weights` reach the network and the weighted-sum path executes.
- [x] A/B check: extreme weights (e.g. edge=1 vs seg=1) now produce different outputs (previously byte-identical).
- [x] Single-control transfer paths unaffected (they use the static-shape `two_way_attention`).
