### PR TITLE
deps: use natten gb300 (sm_103) wheel for x86_64 cu130

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,9 +203,9 @@ cu128-train = [
 cu130 = [
   "flash-attn-3-nv==1.0.3+cu130.torch210; platform_machine == 'x86_64'",
   "flash-attn==2.7.4.post1+cu130.torch210; platform_machine == 'x86_64'",
-  # aarch64 (GB300/sm_103a): use the custom build that includes sm_103a kernels.
+  # GB300/B300 (sm_103a): use the custom build that includes sm_103a kernels (both arches).
   "natten==0.21.6.dev6+cu130.torch210.gb300; platform_machine == 'aarch64'",
-  "natten==0.21.6.dev6+cu130.torch210; platform_machine == 'x86_64'",
+  "natten==0.21.6.dev6+cu130.torch210.gb300; platform_machine == 'x86_64'",
   "torch==2.10.0+cu130",
   "torchcodec==0.10.0+cu130", # https://github.com/meta-pytorch/torchcodec/releases
   "torchvision==0.25.0+cu130", # https://github.com/pytorch/vision/releases

--- a/uv.lock
+++ b/uv.lock
@@ -1922,8 +1922,7 @@ cu128-train = [
 cu130 = [
     { name = "flash-attn", version = "2.7.4.post1+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'x86_64'" },
     { name = "flash-attn-3-nv", version = "1.0.3+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'x86_64'" },
-    { name = "natten", version = "0.21.6.dev6+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "(platform_machine == 'x86_64' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu128-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu130-train' and extra == 'group-16-cosmos-framework-vllm')" },
-    { name = "natten", version = "0.21.6.dev6+cu130.torch210.gb300", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "(platform_machine == 'aarch64' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu128-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu130-train' and extra == 'group-16-cosmos-framework-vllm')" },
+    { name = "natten", version = "0.21.6.dev6+cu130.torch210.gb300", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "nvidia-cublas" },
     { name = "nvidia-cuda-cupti" },
     { name = "nvidia-cuda-nvrtc" },
@@ -1947,8 +1946,7 @@ cu130 = [
 cu130-train = [
     { name = "flash-attn", version = "2.7.4.post1+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'x86_64'" },
     { name = "flash-attn-3-nv", version = "1.0.3+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'x86_64'" },
-    { name = "natten", version = "0.21.6.dev6+cu130.torch210", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "(platform_machine == 'x86_64' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu128-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-vllm')" },
-    { name = "natten", version = "0.21.6.dev6+cu130.torch210.gb300", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "(platform_machine == 'aarch64' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu128-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu128-train' and extra == 'group-16-cosmos-framework-vllm') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-cu130-train') or (extra == 'group-16-cosmos-framework-cu130' and extra == 'group-16-cosmos-framework-vllm')" },
+    { name = "natten", version = "0.21.6.dev6+cu130.torch210.gb300", source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
     { name = "nvidia-cublas" },
     { name = "nvidia-cuda-cupti" },
     { name = "nvidia-cuda-nvrtc" },
@@ -2178,7 +2176,7 @@ cu130 = [
     { name = "flash-attn", marker = "platform_machine == 'x86_64'", specifier = "==2.7.4.post1+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "flash-attn-3-nv", marker = "platform_machine == 'x86_64'", specifier = "==1.0.3+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "natten", marker = "platform_machine == 'aarch64'", specifier = "==0.21.6.dev6+cu130.torch210.gb300", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
-    { name = "natten", marker = "platform_machine == 'x86_64'", specifier = "==0.21.6.dev6+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
+    { name = "natten", marker = "platform_machine == 'x86_64'", specifier = "==0.21.6.dev6+cu130.torch210.gb300", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "nvidia-cublas", specifier = "==13.1.0.3" },
     { name = "nvidia-cuda-cupti", specifier = "==13.0.85" },
     { name = "nvidia-cuda-nvrtc", specifier = "==13.0.88" },
@@ -2203,7 +2201,7 @@ cu130-train = [
     { name = "flash-attn", marker = "platform_machine == 'x86_64'", specifier = "==2.7.4.post1+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "flash-attn-3-nv", marker = "platform_machine == 'x86_64'", specifier = "==1.0.3+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "natten", marker = "platform_machine == 'aarch64'", specifier = "==0.21.6.dev6+cu130.torch210.gb300", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
-    { name = "natten", marker = "platform_machine == 'x86_64'", specifier = "==0.21.6.dev6+cu130.torch210", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
+    { name = "natten", marker = "platform_machine == 'x86_64'", specifier = "==0.21.6.dev6+cu130.torch210.gb300", index = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" },
     { name = "nvidia-cublas", specifier = "==13.1.0.3" },
     { name = "nvidia-cuda-cupti", specifier = "==13.0.85" },
     { name = "nvidia-cuda-nvrtc", specifier = "==13.0.88" },
@@ -7120,43 +7118,33 @@ wheels = [
 
 [[package]]
 name = "natten"
-version = "0.21.6.dev6+cu130.torch210"
-source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform != 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform != 'linux'",
-]
-wheels = [
-    { url = "https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210-cp313-cp313-linux_aarch64.whl", hash = "sha256:d157abf86d3f01aa683ef6637abce4f1fdf2b7aa86b5af52736e5d53e9c42da5" },
-    { url = "https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210-cp313-cp313-linux_x86_64.whl", hash = "sha256:13d81645a33e58500c33f4c8840c992cab1bf43b2f476b96e7a70c3864906511" },
-]
-
-[[package]]
-name = "natten"
 version = "0.21.6.dev6+cu130.torch210.gb300"
 source = { registry = "https://nvidia-cosmos.github.io/cosmos-dependencies/v1.5.0" }
 resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform != 'linux'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform != 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
     "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform != 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform != 'linux'",
     "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform != 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform != 'linux'",
     "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform != 'linux'",
 ]
 wheels = [
     { url = "https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210.gb300-cp313-cp313-linux_aarch64.whl", hash = "sha256:cd63a31be0ea73c3f5d8bded442508e02a74fc9827f56f92b89314498a2fde9b" },
+    { url = "https://github.com/nvidia-cosmos/cosmos-dependencies/releases/download/v1.5.0/natten-0.21.6.dev6%2Bcu130.torch210.gb300-cp313-cp313-linux_x86_64.whl", hash = "sha256:04ace5d591b2775149d7a9adc8f3e6099b18fedad364c48e70b4a998ee598b9c" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
On **x86_64**, the `cu130` dependency group pinned the stock natten wheel `natten==0.21.6.dev6+cu130.torch210`, which does **not** contain `sm_103a` kernels. On B300 / GB300 (compute capability 10.3) this fails at runtime with `no kernel image is available for execution on the device`.

## Change
- Point x86_64 cu130 natten at `==0.21.6.dev6+cu130.torch210.gb300`, mirroring the existing aarch64 entry. That build appends `10.3 -> sm_103a` to `NATTEN_CUDA_ARCH`.
- Regenerated `uv.lock` (now resolves the x86_64 gb300 wheel, sha256 `04ace5d5…`).

The wheel is published in the cosmos index via nvidia-cosmos/cosmos-dependencies#60.

## Verification
- `uv lock --check` passes (lock consistent with pyproject).
- End-to-end: `Cosmos3-Nano` t2i inference on a B300 (sm_103) completes successfully — 960×960 image generated, no "no kernel image" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)