### PR TITLE
Release: sync from internal

### DIFF
--- a/cosmos_framework/callbacks/every_n_draw_sample.py
+++ b/cosmos_framework/callbacks/every_n_draw_sample.py
@@ -4,8 +4,9 @@
 import math
 import os
 from contextlib import nullcontext
+from dataclasses import dataclass
 from functools import partial
-from typing import List, Optional
+from typing import Any
 
 import numpy as np
 import torch
@@ -22,6 +23,8 @@ from cosmos_framework.utils import distributed, log, misc
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.tools.visualize.video import save_img_or_video
 from cosmos_framework.utils.generator.data_utils import slice_data_batch
+
+WandbImagePaths = str | dict[str, str]
 
 
 def resize_image(image: torch.Tensor, size: int = 1024) -> torch.Tensor:
@@ -49,7 +52,7 @@ def convert_to_primitive(value):
         return "non-primitive"  # Skip non-primitive types
 
 
-def pad_images_and_cat(images: List[torch.Tensor], max_w: int, max_h: int, t_crop: int = 1) -> torch.Tensor:
+def pad_images_and_cat(images: list[torch.Tensor], max_w: int, max_h: int, t_crop: int = 1) -> torch.Tensor:
     """
     Pad images to a common size and concatenate them along the batch dimension.
 
@@ -83,6 +86,137 @@ def pad_images_and_cat(images: List[torch.Tensor], max_w: int, max_h: int, t_cro
     return torch.cat(padded_images, dim=0)  # [total_B,C,T,max_h,max_w]  (total_B = sum of batch dims)
 
 
+@dataclass(frozen=True, slots=True)
+class MultiviewTransferMetadata:
+    num_vision_items: int
+    sample_n_views: int
+    num_video_frames_per_view: int
+
+
+@dataclass(frozen=True, slots=True)
+class MultiviewTransferSampleResult:
+    handled: bool
+    image_paths: WandbImagePaths | None = None
+
+
+def _flatten_int_metadata(value: Any) -> list[int] | None:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        flat_value = value.detach().cpu().flatten()  # [N_metadata]
+        return [int(item) for item in flat_value.tolist()]
+    if isinstance(value, (list, tuple)):
+        values: list[int] = []
+        for item in value:
+            if isinstance(item, torch.Tensor):
+                flat_item = item.detach().cpu().flatten()  # [N_metadata]
+                values.extend(int(v) for v in flat_item.tolist())
+            elif isinstance(item, (int, np.integer)):
+                values.append(int(item))
+            else:
+                return None
+        return values
+    if isinstance(value, (int, np.integer)):
+        return [int(value)]
+    return None
+
+
+def _first_positive_metadata_value(data_batch: dict[str, Any], key: str) -> int | None:
+    values = _flatten_int_metadata(data_batch.get(key))
+    if not values:
+        return None
+    value = values[0]
+    return value if value > 0 else None
+
+
+def _get_multiview_transfer_metadata(
+    data_batch: dict[str, Any],
+    num_vision_items_per_sample: Any,
+) -> MultiviewTransferMetadata | None:
+    if "sample_n_views" not in data_batch or "num_video_frames_per_view" not in data_batch:
+        return None
+
+    num_items = _flatten_int_metadata(num_vision_items_per_sample)
+    if not num_items:
+        return None
+
+    sample_n_views = _first_positive_metadata_value(data_batch, "sample_n_views")
+    num_video_frames_per_view = _first_positive_metadata_value(data_batch, "num_video_frames_per_view")
+    if num_items[0] < 2 or sample_n_views is None or num_video_frames_per_view is None:
+        return None
+
+    return MultiviewTransferMetadata(
+        num_vision_items=num_items[0],
+        sample_n_views=sample_n_views,
+        num_video_frames_per_view=num_video_frames_per_view,
+    )
+
+
+def _split_multiview_tensor_by_view(
+    tensor: torch.Tensor,
+    sample_n_views: int,
+    num_video_frames_per_view: int,
+) -> torch.Tensor | None:
+    if tensor.dim() == 5:
+        if tensor.shape[0] != 1:
+            return None
+        view_tensor = tensor[0]  # [C,V*F,H,W]
+    elif tensor.dim() == 4:
+        view_tensor = tensor  # [C,V*F,H,W]
+    else:
+        return None
+
+    expected_num_frames = sample_n_views * num_video_frames_per_view
+    if view_tensor.shape[1] != expected_num_frames:
+        return None
+
+    view_tensor = view_tensor.reshape(
+        view_tensor.shape[0],
+        sample_n_views,
+        num_video_frames_per_view,
+        view_tensor.shape[2],
+        view_tensor.shape[3],
+    )  # [C,V,F,H,W]
+    return view_tensor.permute(1, 0, 2, 3, 4).contiguous()  # [V,C,F,H,W]
+
+
+def _get_first_multiview_transfer_rows(
+    raw_data: list[torch.Tensor] | None,
+    metadata: MultiviewTransferMetadata,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    if raw_data is None or len(raw_data) < metadata.num_vision_items:
+        return None
+
+    control_video = _split_multiview_tensor_by_view(
+        raw_data[0],
+        metadata.sample_n_views,
+        metadata.num_video_frames_per_view,
+    )  # [V,C,F,H,W] or None
+    gt_target_video = _split_multiview_tensor_by_view(
+        raw_data[metadata.num_vision_items - 1],
+        metadata.sample_n_views,
+        metadata.num_video_frames_per_view,
+    )  # [V,C,F,H,W] or None
+    if control_video is None or gt_target_video is None:
+        return None
+    return control_video, gt_target_video
+
+
+def _add_wandb_image_paths(
+    info: dict[str, Any],
+    key_prefix: str,
+    image_paths: WandbImagePaths | None,
+    caption: str,
+) -> None:
+    if image_paths is None:
+        return
+    if isinstance(image_paths, dict):
+        for key_suffix, image_path in image_paths.items():
+            info[f"{key_prefix}_{key_suffix}"] = wandb.Image(image_path, caption=caption)
+        return
+    info[key_prefix] = wandb.Image(image_paths, caption=caption)
+
+
 class EveryNDrawSample(EveryN):
     """
     This callback sample condition inputs from training data, run inference and save the results to wandb and s3.
@@ -93,7 +227,7 @@ class EveryNDrawSample(EveryN):
         n_viz_sample (int, optional): for each batch, min(n_viz_sample, batch_size) samples will be saved to wandb. Defaults to 3.
         n_sample_to_save (int, optional): number of samples to save. The actual number of samples to save is min(n_sample_to_save, data parallel instances). Defaults to 128.
         num_sampling_step (int, optional): number of sampling steps. Defaults to 35.
-        guidance (List[float], optional): guidance scale. Defaults to [0.0, 3.0, 7.0].
+        guidance (list[float], optional): guidance scale. Defaults to [0.0, 3.0, 7.0].
         do_x0_prediction (bool, optional): whether to do x0 prediction. Defaults to True.
         n_sigmas_for_x0_prediction (int, optional): number of sigmas to use for x0 prediction. Defaults to 4.
         save_s3 (bool, optional): whether to save to s3. Defaults to False.
@@ -109,7 +243,7 @@ class EveryNDrawSample(EveryN):
         n_viz_sample: int = 2,
         n_sample_to_save: int = 128,
         num_sampling_step: int = 35,
-        guidance: List[float] = [0.0, 3.0, 7.0],
+        guidance: list[float] = [0.0, 3.0, 7.0],
         do_x0_prediction: bool = True,
         n_sigmas_for_x0_prediction: int = 4,
         save_s3: bool = False,
@@ -119,9 +253,9 @@ class EveryNDrawSample(EveryN):
         prompt_type: str = "t5_xxl",
         fps: int = 16,
         run_at_start: bool = False,
-    ):
+    ) -> None:
         # s3: # files: min(n_sample_to_save, data instance)  # per file: min(batch_size, n_viz_sample)
-        # wandb: 1 file, # per file: min(batch_size, n_viz_sample)
+        # wandb: normal paths log one preview; multiview transfer logs one preview per selected timestamp.
         super().__init__(every_n, step_size, run_at_start=run_at_start)
 
         self.n_viz_sample = n_viz_sample
@@ -196,7 +330,15 @@ class EveryNDrawSample(EveryN):
         return local_path, torch.tensor(mse_loss_list).cuda(), sigmas  # [N_sigmas]
 
     @torch.no_grad()
-    def every_n_impl(self, trainer, model, data_batch, output_batch, loss, iteration):
+    def every_n_impl(
+        self,
+        trainer: Any,
+        model: Any,
+        data_batch: dict[str, Any],
+        output_batch: Any,
+        loss: Any,
+        iteration: int,
+    ) -> None:
         if self.is_ema:
             if not model.config.ema.enabled:
                 return
@@ -266,20 +408,85 @@ class EveryNDrawSample(EveryN):
                 "sample_counter": sample_counter,
             }
             if self.do_x0_prediction:
-                info[f"{self.name}/{tag}_x0"] = wandb.Image(x0_img_fp, caption=f"{sample_counter}")
+                _add_wandb_image_paths(info, f"{self.name}/{tag}_x0", x0_img_fp, f"{sample_counter}")
                 # convert mse_loss to a dict
                 mse_loss = mse_loss.tolist()
                 info.update({f"x0_pred_mse_{tag}/Sigma{sigmas[i]:0.5f}": mse_loss[i] for i in range(len(mse_loss))})
 
-            info[f"{self.name}/{tag}_sample"] = wandb.Image(sample_img_fp, caption=f"{sample_counter}")
+            _add_wandb_image_paths(info, f"{self.name}/{tag}_sample", sample_img_fp, f"{sample_counter}")
             wandb.log(
                 info,
                 step=iteration,
             )
         torch.cuda.empty_cache()
 
+    def _sample_multiview_transfer(
+        self,
+        model: Any,
+        data_batch: dict[str, Any],
+        raw_data: list[torch.Tensor] | None,
+        metadata: MultiviewTransferMetadata,
+        iteration: int,
+        tag: str,
+    ) -> MultiviewTransferSampleResult:
+        first_sample_rows = _get_first_multiview_transfer_rows(raw_data, metadata)
+        if first_sample_rows is None:
+            return MultiviewTransferSampleResult(handled=False)
+
+        control_video, gt_target_video = first_sample_rows
+        to_show = [
+            control_video.float().cpu(),  # [V,C,F,H,W]
+            gt_target_video.float().cpu(),  # [V,C,F,H,W]
+        ]
+
+        generation_batch = slice_data_batch(data_batch, start=0, limit=1)
+        for guidance in self.guidance:
+            sample = model.generate_samples_from_batch(
+                generation_batch,
+                guidance=guidance,
+                n_sample=1,
+                num_steps=self.num_sampling_step,
+                has_negative_prompt=True if self.use_negative_prompt else False,
+                seed=[iteration],
+            )
+            sample_vision = sample["vision"]
+            if len(sample_vision) != 1:
+                return MultiviewTransferSampleResult(handled=True)
+            assert hasattr(model, "decode")
+            generated_video = model.decode(sample_vision[0])  # [1,C,V*F,H,W] or [C,V*F,H,W]
+            generated_by_view = _split_multiview_tensor_by_view(
+                generated_video,
+                metadata.sample_n_views,
+                metadata.num_video_frames_per_view,
+            )  # [V,C,F,H,W] or None
+            if generated_by_view is None:
+                return MultiviewTransferSampleResult(handled=True)
+            to_show.append(generated_by_view.float().cpu())  # [V,C,F,H,W]
+
+        if any(row.shape != to_show[0].shape for row in to_show):
+            return MultiviewTransferSampleResult(handled=True)
+
+        base_fp_wo_ext = f"{tag}_ReplicateID{self.data_parallel_id:04d}_Sample_Iter{iteration:09d}"
+        base_fp_wo_ext = f"Iter{iteration:09d}/{base_fp_wo_ext}"
+        image_paths = self.run_save(
+            to_show,
+            metadata.sample_n_views,
+            base_fp_wo_ext,
+            max_columns=metadata.sample_n_views,
+            split_video_frames_for_wandb=True,
+        )
+        return MultiviewTransferSampleResult(handled=True, image_paths=image_paths)
+
     @misc.timer("EveryNDrawSample: sample")
-    def sample(self, trainer, model, data_batch, output_batch, loss, iteration):
+    def sample(
+        self,
+        trainer: Any,
+        model: Any,
+        data_batch: dict[str, Any],
+        output_batch: Any,
+        loss: Any,
+        iteration: int,
+    ) -> WandbImagePaths | None:
         data_batch = slice_data_batch(data_batch, start=0, limit=self.n_viz_sample)
 
         tag = "ema" if self.is_ema else "reg"
@@ -303,6 +510,18 @@ class EveryNDrawSample(EveryN):
         # Check if this is a multi-item vision batch (image editing)
         num_items = data_clean.num_vision_items_per_sample
         is_multi_item = num_items is not None
+        multiview_metadata = _get_multiview_transfer_metadata(data_batch, num_items)
+        if multiview_metadata is not None:
+            multiview_result = self._sample_multiview_transfer(
+                model,
+                data_batch,
+                raw_data,
+                multiview_metadata,
+                iteration,
+                tag,
+            )
+            if multiview_result.handled:
+                return multiview_result.image_paths
 
         if is_multi_item:
             # Image editing: raw_data is flat [src1, tgt1, src2, tgt2, ...].
@@ -365,11 +584,19 @@ class EveryNDrawSample(EveryN):
         local_path = self.run_save(to_show, batch_size, base_fp_wo_ext)
         return local_path
 
-    def run_save(self, to_show, batch_size, base_fp_wo_ext) -> Optional[str]:
+    def run_save(
+        self,
+        to_show: list[torch.Tensor],
+        batch_size: int,
+        base_fp_wo_ext: str,
+        max_columns: int | None = None,
+        split_video_frames_for_wandb: bool = False,
+    ) -> WandbImagePaths | None:
         to_show = (1.0 + torch.stack(to_show, dim=0).clamp(-1, 1)) / 2.0  # [N_rows,B,C,T,H,W]  range [0,1]
         is_single_frame = to_show.shape[3] == 1
-        n_viz_sample = min(self.n_viz_sample, batch_size)
-        to_show = to_show[:, :n_viz_sample]
+        max_columns = self.n_viz_sample if max_columns is None else max_columns
+        n_columns = min(max_columns, batch_size)
+        to_show = to_show[:, :n_columns]
 
         # ! we only save first n_sample_to_save video!
         video_grid = rearrange(to_show, "n b c t h w -> c t (n h) (b w)")  # [C,T,N_rows*H,B*W]
@@ -390,33 +617,64 @@ class EveryNDrawSample(EveryN):
         if self.rank == 0 and wandb.run:
             if is_single_frame:  # image case
                 to_show = rearrange(
-                    to_show[:, :n_viz_sample],
+                    to_show[:, :n_columns],
                     "n b c t h w -> t c (n h) (b w)",
                 )  # [1,C,N_rows*H,B*W]  (t=1 for images)
-                image_grid = torchvision.utils.make_grid(to_show, nrow=1, padding=0, normalize=False)
+                image_grid = torchvision.utils.make_grid(
+                    to_show, nrow=1, padding=0, normalize=False
+                )  # [C,N_rows*H,B*W]
                 # resize so that wandb can handle it
                 os.makedirs(os.path.dirname(local_path), exist_ok=True)
-                torchvision.utils.save_image(resize_image(image_grid, 1024), local_path, nrow=1, scale_each=True)
+                resized_image = resize_image(image_grid, 1024)  # [C,H_resize,W_resize]
+                torchvision.utils.save_image(resized_image, local_path, nrow=1, scale_each=True)
             else:
-                to_show = to_show[:, :n_viz_sample]  # [N_rows,B,C,T,H,W]
+                to_show = to_show[:, :n_columns]  # [N_rows,B,C,T,H,W]
 
                 # resize 3 frames frames so that we can display them on wandb
                 _T = to_show.shape[3]
                 three_frames_list = [0, _T // 2, _T - 1]
-                to_show = to_show[:, :, :, three_frames_list]  # [N_rows,B,C,3,H,W]  (3 sampled frames)
                 log_image_size = 1024
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
+                if split_video_frames_for_wandb:
+                    frame_paths: dict[str, str] = {}
+                    for frame_name, frame_idx in zip(
+                        ("frame_first", "frame_mid", "frame_last"),
+                        three_frames_list,
+                        strict=True,
+                    ):
+                        frame_to_show = to_show[:, :, :, frame_idx]  # [N_rows,B,C,H,W]
+                        frame_to_show = rearrange(
+                            frame_to_show,
+                            "n b c h w -> 1 c (n h) (b w)",
+                        )  # [1,C,N_rows*H,B*W]
+                        frame_image_grid = torchvision.utils.make_grid(
+                            frame_to_show,
+                            nrow=1,
+                            padding=0,
+                            normalize=False,
+                        )  # [C,N_rows*H,B*W]
+                        frame_path = f"{self.local_dir}/{base_fp_wo_ext}_{frame_name}_resize.jpg"
+                        resized_frame = resize_image(frame_image_grid, log_image_size)  # [C,H_resize,W_resize]
+                        torchvision.utils.save_image(resized_frame, frame_path, nrow=1, scale_each=True)
+                        frame_paths[frame_name] = frame_path
+                    return frame_paths
+
+                to_show = to_show[:, :, :, three_frames_list]  # [N_rows,B,C,3,H,W]  (3 sampled frames)
                 to_show = rearrange(
                     to_show,
                     "n b c t h w -> 1 c (n h) (b t w)",
                 )  # [1,C,N_rows*H,B*3*W]  (t=3 sampled frames)
 
-                os.makedirs(os.path.dirname(local_path), exist_ok=True)
                 # resize so that wandb can handle it
-                image_grid = torchvision.utils.make_grid(to_show, nrow=1, padding=0, normalize=False)
-                os.makedirs(os.path.dirname(local_path), exist_ok=True)
-                torchvision.utils.save_image(
-                    resize_image(image_grid, log_image_size), local_path, nrow=1, scale_each=True
-                )
+                image_grid = torchvision.utils.make_grid(
+                    to_show,
+                    nrow=1,
+                    padding=0,
+                    normalize=False,
+                )  # [C,N_rows*H,B*3*W]
+                resized_image = resize_image(image_grid, log_image_size)  # [C,H_resize,W_resize]
+                torchvision.utils.save_image(resized_image, local_path, nrow=1, scale_each=True)
 
             return local_path
         return None

--- a/cosmos_framework/configs/base/reasoner/config.py
+++ b/cosmos_framework/configs/base/reasoner/config.py
@@ -7,6 +7,7 @@ from cosmos_framework.utils.config_helper import import_all_modules_from_package
 from cosmos_framework.configs.base.defaults.checkpointer import register_checkpoint, register_ckpt_type
 from cosmos_framework.configs.base.reasoner.defaults.callbacks import register_callbacks
 from cosmos_framework.configs.base.reasoner.defaults.config import Config
+
 from cosmos_framework.configs.base.reasoner.defaults.model import register_model
 from cosmos_framework.configs.base.reasoner.defaults.optimizer import register_optimizer, register_scheduler
 from cosmos_framework.configs.base.reasoner.defaults.vlm_policy import register_vlm_policy

--- a/cosmos_framework/data/generator/augmentors/text_transforms_for_image.py
+++ b/cosmos_framework/data/generator/augmentors/text_transforms_for_image.py
@@ -9,7 +9,6 @@ from cosmos_framework.data.imaginaire.webdataset.augmentors.v3_text_transforms i
 from cosmos_framework.data.imaginaire.webdataset.augmentors.augmentor import Augmentor
 from cosmos_framework.utils import log
 
-# COSMOS-RELEASE-END-IGNORE
 
 # For the qwen captions, we have 3 variants: short, medium, long
 # In addition, for synthetic data, we create prompt embeddings as well.

--- a/cosmos_framework/data/reasoner/processors/nemotronvl_processor.py
+++ b/cosmos_framework/data/reasoner/processors/nemotronvl_processor.py
@@ -84,15 +84,15 @@ nemotron_chat_template = """
         {{- ', ' if not loop.last else '' -}}
     {%- endfor -%}
     {{- ']</AVAILABLE_TOOLS>\n\n' -}}
-    
+
     {{- 'If you decide to call any tool(s), use the following format:\n' -}}
     {{- '<TOOLCALL>[{"name": "tool_name1", "arguments": "tool_args1"}, ' -}}
     {{- '{"name": "tool_name2", "arguments": "tool_args2"}]</TOOLCALL>\n\n' -}}
-    
+
     {{- 'The user will execute tool-calls and return responses from tool(s) in this format:\n' -}}
     {{- '<TOOL_RESPONSE>[{"response": "tool_response1"}, ' -}}
     {{- '{"response": "tool_response2"}]</TOOL_RESPONSE>\n\n' -}}
-    
+
     {{- 'Based on the tool responses, you can call additional tools if needed, ' -}}
     {{- 'correct tool calls if any errors are found, or just respond to the user.' -}}
 {%- endif -%}

--- a/cosmos_framework/model/generator/mot/context_parallel_test.py
+++ b/cosmos_framework/model/generator/mot/context_parallel_test.py
@@ -41,6 +41,7 @@ from cosmos_framework.data.generator.sequence_packing.runtime import (
 from cosmos_framework.utils.generator.parallelism import ParallelDims
 
 
+
 def _broadcast_test_object(data: Any, parallel_dims: ParallelDims, iteration: int) -> Any:
     rank = parallel_dims.cp_rank
     cp_world_size = parallel_dims.cp_mesh.size()

--- a/cosmos_framework/model/tokenizer/evaluation/reconstruction_metrics.py
+++ b/cosmos_framework/model/tokenizer/evaluation/reconstruction_metrics.py
@@ -495,6 +495,5 @@ __all__ = [
     "SSIMMetric",
     "LPIPSMetric",
     "Rank0FIDMetric",
-    "FVDMetric",
     "calculate_psnr",
 ]


### PR DESCRIPTION
Standard cosmos-framework-release pipeline run against current main. Clean drift gate (no SOURCE/DEST breaks).

* callbacks/every_n_draw_sample.py — refreshed to i4 head (+306/-27, new sampling logic from upstream).
* nemotronvl_processor.py — trailing-whitespace cleanup from i4.
* config.py / text_transforms_for_image.py / context_parallel_test.py — blank-line normalization from the i4 ruff-format pass.

_source_commit (i4): cf2697ab
_dest_commit (cf base): dff69664