### PR TITLE
Sync Cosmos3 Diffusers converter support

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -76,7 +76,7 @@ jobs:
   generator-training-regression:
     needs: pre-commit
     runs-on: [self-hosted, gpu, h200]
-    timeout-minutes: 60
+    timeout-minutes: 75
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_DISABLE_XET: "1"
@@ -90,12 +90,14 @@ jobs:
       - name: Sync environment (cu128-train)
         run: uv sync --all-extras --group=cu128-train
 
-      # Generator (vision_sft_nano) loss vs the h100 goldens. -s streams the live log.
-      - name: Generator regression (vision_sft_nano, 4-GPU subset)
+      # Generator (vision_sft_nano) loss vs the h100 goldens, plus a Nano DCP ->
+      # Diffusers conversion that validates the exported component files and indexes.
+      # Both tests share the module-scoped staged Nano DCP. -s streams the live log.
+      - name: Generator regression and Nano Diffusers export (4-GPU subset)
         run: |
           export LD_LIBRARY_PATH=
           uv run --all-extras --group=cu128-train python -m pytest -v -s \
-            tests/launch_regression_test.py -k vision_sft_nano \
+            tests/launch_regression_test.py -k 'vision_sft_nano or convert_model_to_diffusers' \
             --num-gpus=4 --levels=2 -o addopts=
 
       # The h100_inputs fixture removes its DCP stage on teardown; clear the

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -10,7 +10,7 @@
 #   * training-smoke                — Nano SFT pipeline (convert -> train 5 -> export -> t2i)
 #   * generator-training-regression — vision_sft_nano loss vs goldens (4-GPU subset)
 #   * generator-inference-smoke     — Nano multi-modality inference (t2vs + policy + forward_dynamics)
-#   * reasoner-inference-smoke      — Nano reasoner inference first-token logits vs golden (image-conditioned, 4-GPU)
+#   * reasoner-inference-smoke      — Nano reasoner inference golden + Qwen conversion coverage (4-GPU)
 #   * reasoner-training-regression  — llava_ov loss vs goldens (4-GPU subset)
 #
 # Requires:
@@ -171,8 +171,20 @@ jobs:
             tests/nano_reasoner_inference_smoke_test.py::test_nano_reasoner_image_first_token_logits \
             --num-gpus=4 --levels=2 -o addopts=
 
-      # Reasoner inference writes only the pytest tmp dir (generated text + logs);
-      # the checkpoint download stays in the HF cache (kept).
+      # Merge Cosmos3-Nano into the public Qwen3-VL shell and verify that every
+      # Qwen tensor is present and both the vision and language towers come from
+      # Cosmos3-Nano. The exact node ID avoids collecting the training regressions
+      # in the same file.
+      - name: Nano reasoner Qwen tensor conversion coverage (4 GPU collection)
+        run: |
+          export LD_LIBRARY_PATH=
+          uv run --all-extras --group=cu128-train python -m pytest -v -s \
+            tests/launch_regression_test.py::test_convert_reasoner_converts_all_qwen_tensors \
+            --num-gpus=4 --levels=2 -o addopts=
+
+      # Reasoner inference and conversion write to pytest tmp dirs (generated
+      # text, logs, and the merged checkpoint); downloaded checkpoints stay in
+      # the HF cache (kept).
       - name: Clean up run outputs
         if: always()
         run: |

--- a/cosmos_framework/scripts/_convert_model_to_diffusers.py
+++ b/cosmos_framework/scripts/_convert_model_to_diffusers.py
@@ -99,6 +99,8 @@ _ATTN_KEY_REMAP = (
     (".k_norm.", ".norm_k."),
 )
 
+_LANGUAGE_MODEL_VISION_PREFIXES = ("model.visual.", "visual.")
+
 # Legacy TimestepEmbedder stored its MLP as `nn.Sequential([Linear, SiLU, Linear])`,
 # so state-dict keys were `mlp.0.*` / `mlp.2.*`. The diffusers `TimestepEmbedding`
 # stores them as named attributes `linear_1` / `linear_2`. Index 1 (SiLU) has no
@@ -139,6 +141,22 @@ def _remap_language_model_key(key: str) -> str:
             key = key.replace(old, new)
             break
     return key
+
+
+def _remap_language_model_state_dict(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Remap language-model keys and reject ambiguous source layouts."""
+    remapped_state_dict: dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if key.startswith(_LANGUAGE_MODEL_VISION_PREFIXES):
+            continue
+        remapped_key = _remap_language_model_key(key)
+        if remapped_key in remapped_state_dict:
+            raise RuntimeError(
+                "Language-model key remap collision while applying diffusers key remap: "
+                f"{key!r} maps to existing key {remapped_key!r}."
+            )
+        remapped_state_dict[remapped_key] = value
+    return remapped_state_dict
 
 
 def _load_sound_tokenizer_state_dict(checkpoint_path: pathlib.Path) -> dict[str, torch.Tensor]:
@@ -615,18 +633,22 @@ def convert_model_to_diffusers(args: Args) -> None:
     unified_3d_mrope_temporal_modality_margin = (
         _tmp.config.diffusion_expert_config.unified_3d_mrope_temporal_modality_margin
     )
-    action2llm = getattr(_tmp.net, "action2llm", None)
-    llm2action = getattr(_tmp.net, "llm2action", None)
+    action_proj_in = getattr(_tmp.net, "action2llm", None)
+    if action_proj_in is None:
+        action_proj_in = getattr(_tmp.net, "action_proj_in", None)
+    action_proj_out = getattr(_tmp.net, "llm2action", None)
+    if action_proj_out is None:
+        action_proj_out = getattr(_tmp.net, "action_proj_out", None)
     action_modality_embed = getattr(_tmp.net, "action_modality_embed", None)
     has_action_projection_weights = any(
-        module is not None for module in (action2llm, llm2action, action_modality_embed)
+        module is not None for module in (action_proj_in, action_proj_out, action_modality_embed)
     )
     action_gen = bool(
         _get_config_value(net_cfg, model_cfg, name="action_gen", default=False) or has_action_projection_weights
     )
     action_dim = _get_config_value(net_cfg, model_cfg, name="action_dim", default=None)
-    if action_dim is None and action2llm is not None:
-        action_dim = getattr(action2llm, "input_size", None)
+    if action_dim is None and action_proj_in is not None:
+        action_dim = getattr(action_proj_in, "input_size", None)
     if action_dim is None:
         action_dim = max_action_dim
     num_embodiment_domains = int(_get_config_value(net_cfg, model_cfg, name="num_embodiment_domains", default=32))
@@ -662,8 +684,8 @@ def convert_model_to_diffusers(args: Args) -> None:
         missing_action_modules = [
             name
             for name, module in (
-                ("action2llm", action2llm),
-                ("llm2action", llm2action),
+                ("action_proj_in/action2llm", action_proj_in),
+                ("action_proj_out/llm2action", action_proj_out),
                 ("action_modality_embed", action_modality_embed),
             )
             if module is None
@@ -718,7 +740,7 @@ def convert_model_to_diffusers(args: Args) -> None:
             unified_3d_mrope_temporal_modality_margin=unified_3d_mrope_temporal_modality_margin,
             vocab_size=lm_cfg.vocab_size,
         )
-    state_dict = {_remap_language_model_key(k): v for k, v in language_model.state_dict().items()}
+    state_dict = _remap_language_model_state_dict(language_model.state_dict())
     for k, v in vae2llm.state_dict().items():
         state_dict[f"proj_in.{k}"] = v
     for k, v in llm2vae.state_dict().items():
@@ -726,9 +748,9 @@ def convert_model_to_diffusers(args: Args) -> None:
     for k, v in time_embedder.state_dict().items():
         state_dict[f"time_embedder.{_TIME_EMBEDDER_KEY_REMAP[k]}"] = v
     if action_gen:
-        for k, v in action2llm.state_dict().items():
+        for k, v in action_proj_in.state_dict().items():
             state_dict[f"action_proj_in.{k}"] = v
-        for k, v in llm2action.state_dict().items():
+        for k, v in action_proj_out.state_dict().items():
             state_dict[f"action_proj_out.{k}"] = v
         state_dict["action_modality_embed"] = action_modality_embed
     if sound_gen:
@@ -743,8 +765,8 @@ def convert_model_to_diffusers(args: Args) -> None:
         vae2llm,
         llm2vae,
         time_embedder,
-        action2llm,
-        llm2action,
+        action_proj_in,
+        action_proj_out,
         action_modality_embed,
         sound2llm,
         llm2sound,

--- a/cosmos_framework/scripts/convert_model_to_diffusers.py
+++ b/cosmos_framework/scripts/convert_model_to_diffusers.py
@@ -11,11 +11,12 @@ init_script(
     }
 )
 
+import copy
 import json
 import shutil
 import struct
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import pydantic
 import tyro
@@ -69,6 +70,25 @@ class SafetensorsIndex(pydantic.BaseModel):
     def update_dir(self, safetensors_dir: Path, rel_path: str):
         for safetensors_path in safetensors_dir.glob("*.safetensors"):
             self.update(safetensors_path, f"{rel_path}/{safetensors_path.name}")
+
+
+def _build_public_export_model_config(model_dict: dict[str, Any]) -> dict[str, Any]:
+    """Remove unsupported internal-only settings before building the public config."""
+    public_model_dict = copy.deepcopy(model_dict)
+    quantization = public_model_dict.get("config", {}).pop("quantization", None)
+    if quantization is not None:
+        quantization_values = {key: value for key, value in quantization.items() if key not in {"_type", "_target_"}}
+        disabled_quantization = {
+            "exclude_regex": [],
+            "include_regex": [],
+            "method": None,
+        }
+        if quantization_values != disabled_quantization:
+            raise ValueError(
+                "Cannot export an enabled or non-default internal quantization config to the public Cosmos3 schema: "
+                f"{quantization_values}"
+            )
+    return build_public_model_config(public_model_dict)
 
 
 def convert_model_to_diffusers(args: Args) -> None:
@@ -162,7 +182,7 @@ def convert_model_to_diffusers(args: Args) -> None:
     # collapse to a single glob spanning both component subdirs. The unified
     # `model.safetensors.index.json` written below dedupes the consolidated shard.
     config_dict["allow_patterns_overrides"] = ["*/*.safetensors"]
-    config_dict["model"] = build_public_model_config(model_dict)
+    config_dict["model"] = _build_public_export_model_config(model_dict)
     serialize_config_dict(config_dict, args.output_path / "config.json")
 
     if not args.config_only:

--- a/cosmos_framework/scripts/convert_model_to_diffusers.py
+++ b/cosmos_framework/scripts/convert_model_to_diffusers.py
@@ -28,6 +28,7 @@ from cosmos_framework.inference.common.public_model_config import (
     build_public_model_config,
     load_model_config_from_hf_config,
 )
+from cosmos_framework.utils import log
 from cosmos_framework.utils.checkpoint_db import CheckpointConfig, CheckpointDirHf
 
 
@@ -39,6 +40,9 @@ class Args(pydantic.BaseModel):
 
     config_only: bool = False
     """If True, only save config."""
+
+    skip_vision_encoder: bool = False
+    """Do not save the vision encoder sidecar in the Diffusers checkpoint."""
 
 
 class SafetensorsIndexMetadata(pydantic.BaseModel):
@@ -67,7 +71,7 @@ class SafetensorsIndex(pydantic.BaseModel):
             self.update(safetensors_path, f"{rel_path}/{safetensors_path.name}")
 
 
-def convert_model_to_diffusers(args: Args):
+def convert_model_to_diffusers(args: Args) -> None:
     args.output_path.mkdir(parents=True, exist_ok=True)
 
     register_checkpoints()
@@ -75,26 +79,45 @@ def convert_model_to_diffusers(args: Args):
     checkpoint_path = checkpoint_config.download_checkpoint()
     model_dict = load_model_config_from_hf_config(deserialize_config_dict(checkpoint_path / "config.json"))
 
-    assert model_dict["config"]["action_gen"]
-    assert model_dict["config"]["sound_gen"]
+    supports_action = model_dict["config"]["action_gen"]
+    supports_sound = model_dict["config"]["sound_gen"]
+    if not supports_action:
+        log.warning(
+            "The checkpoint does not support action generation. For some checkpoints, like "
+            "'Cosmos3-Super-Image2Video' it's fine, but make sure it's expected."
+        )
+    if not supports_sound:
+        log.warning(
+            "The checkpoint does not support sound generation. For some checkpoints, like "
+            "'Cosmos3-Nano-Policy-DROID' it's fine, but make sure it's expected."
+        )
 
-    sound_tokenizer_dir, sound_tokenizer_name = model_dict["config"]["sound_tokenizer"]["avae_path"].rsplit("/", 1)
-    sound_tokenizer_checkpoint = CheckpointConfig.maybe_from_uri(f"s3://bucket/{sound_tokenizer_dir}")
-    assert sound_tokenizer_checkpoint is not None
-    sound_tokenizer_local = Path(sound_tokenizer_checkpoint.hf.download())
-    # HF-published checkpoints ship sound_tokenizer/ in the diffusers layout
-    # (config.json + diffusion_pytorch_model.safetensors), which the converter
-    # consumes directly; fall back to the legacy AVAE file pair named by the
-    # model config's avae_path.
-    sound_tokenizer_path = sound_tokenizer_local / "diffusion_pytorch_model.safetensors"
-    sound_tokenizer_config_path = sound_tokenizer_local / "config.json"
-    if not sound_tokenizer_path.is_file():
-        sound_tokenizer_path = sound_tokenizer_local / sound_tokenizer_name
-        sound_tokenizer_config_path = sound_tokenizer_path.with_suffix(".json")
-    assert sound_tokenizer_path.is_file(), f"Sound tokenizer checkpoint not found: {sound_tokenizer_path}"
-    assert sound_tokenizer_config_path.is_file(), f"Sound tokenizer config not found: {sound_tokenizer_config_path}"
+    sound_tokenizer_path: Path | None = None
+    sound_tokenizer_config_path: Path | None = None
+    if supports_sound and not args.config_only:
+        sound_tokenizer_dir, sound_tokenizer_name = model_dict["config"]["sound_tokenizer"]["avae_path"].rsplit("/", 1)
+        sound_tokenizer_checkpoint = CheckpointConfig.maybe_from_uri(f"s3://bucket/{sound_tokenizer_dir}")
+        assert sound_tokenizer_checkpoint is not None
+        sound_tokenizer_local = Path(sound_tokenizer_checkpoint.hf.download())
+        # HF-published checkpoints ship sound_tokenizer/ in the diffusers layout
+        # (config.json + diffusion_pytorch_model.safetensors), which the converter
+        # consumes directly; fall back to the legacy AVAE file pair named by the
+        # model config's avae_path.
+        sound_tokenizer_path = sound_tokenizer_local / "diffusion_pytorch_model.safetensors"
+        sound_tokenizer_config_path = sound_tokenizer_local / "config.json"
+        if not sound_tokenizer_path.is_file():
+            sound_tokenizer_path = sound_tokenizer_local / sound_tokenizer_name
+            sound_tokenizer_config_path = sound_tokenizer_path.with_suffix(".json")
+        assert sound_tokenizer_path.is_file(), f"Sound tokenizer checkpoint not found: {sound_tokenizer_path}"
+        assert sound_tokenizer_config_path.is_file(), f"Sound tokenizer config not found: {sound_tokenizer_config_path}"
 
-    vision_encoder_model = model_dict["config"]["vlm_config"]["tokenizer"]["pretrained_model_name"]
+    vlm_config = model_dict["config"]["vlm_config"]
+    tokenizer_config = vlm_config["tokenizer"]
+    vision_encoder_model = (
+        tokenizer_config.get("pretrained_model_name")
+        or tokenizer_config.get("tokenizer_type")
+        or vlm_config["model_name"]
+    )
 
     if not args.config_only:
         from cosmos_framework.scripts._convert_model_to_diffusers import (
@@ -109,11 +132,11 @@ def convert_model_to_diffusers(args: Args):
             output=str(args.output_path),
             save_pipeline=True,
             dtype="bf16",
-            sound_tokenizer_path=str(sound_tokenizer_path),
-            sound_tokenizer_config_path=str(sound_tokenizer_config_path),
-            include_sound_tokenizer=True,
+            sound_tokenizer_path=str(sound_tokenizer_path) if sound_tokenizer_path else None,
+            sound_tokenizer_config_path=str(sound_tokenizer_config_path) if sound_tokenizer_config_path else None,
+            include_sound_tokenizer=supports_sound,
             vision_encoder_model=vision_encoder_model,
-            skip_vision_encoder=False,
+            skip_vision_encoder=args.skip_vision_encoder,
         )
         _convert_model_to_diffusers(_args)
 
@@ -127,11 +150,14 @@ def convert_model_to_diffusers(args: Args):
     vlm_checkpoint_path = vlm_checkpoint.download()
     for pattern in vlm_checkpoint.include:
         for p in Path(vlm_checkpoint_path).glob(pattern):
+            if p.name == "model.safetensors.index.json":
+                continue
             shutil.copy(p, args.output_path / p.name)
 
     # Add top-level config
     config_dict = deserialize_config_dict(args.output_path / "config.json")
     config_dict["architectures"] = ["Cosmos3ForConditionalGeneration"]
+    config_dict["model_type"] = "cosmos3_omni"
     # vLLM's `_prepare_weights` breaks after the first pattern with any match, so
     # collapse to a single glob spanning both component subdirs. The unified
     # `model.safetensors.index.json` written below dedupes the consolidated shard.
@@ -139,14 +165,19 @@ def convert_model_to_diffusers(args: Args):
     config_dict["model"] = build_public_model_config(model_dict)
     serialize_config_dict(config_dict, args.output_path / "config.json")
 
-    # Add top-level index
-    index = SafetensorsIndex()
-    index.update_dir(args.output_path / "transformer", "transformer")
-    vision_encoder_rel = "vision_encoder/model.safetensors"
-    index.update(args.output_path / vision_encoder_rel, vision_encoder_rel)
-    (args.output_path / "model.safetensors.index.json").write_text(index.model_dump_json(indent=2))
+    if not args.config_only:
+        # Add top-level index
+        index = SafetensorsIndex()
+        index.update_dir(args.output_path / "transformer", "transformer")
+        vision_encoder_rel = "vision_encoder/model.safetensors"
+        if (args.output_path / vision_encoder_rel).is_file():
+            index.update(args.output_path / vision_encoder_rel, vision_encoder_rel)
+        (args.output_path / "model.safetensors.index.json").write_text(index.model_dump_json(indent=2))
 
-    shutil.copy(checkpoint_path / "checkpoint.json", args.output_path / "checkpoint.json")
+    checkpoint_metadata_path = checkpoint_path / "checkpoint.json"
+    if not checkpoint_metadata_path.is_file():
+        checkpoint_metadata_path = checkpoint_path.parent / "checkpoint.json"
+    shutil.copy(checkpoint_metadata_path, args.output_path / "checkpoint.json")
 
     print(f"Saved diffusers checkpoint to {args.output_path}")
 

--- a/tests/launch_regression_test.py
+++ b/tests/launch_regression_test.py
@@ -540,7 +540,10 @@ def _assert_diffusers_export_complete(model_dir: Path, reference_dir: Path) -> N
 
     pipeline_config = json.loads((model_dir / "model_index.json").read_text())
     assert pipeline_config["_class_name"] == "Cosmos3OmniPipeline"
-    for component in ("scheduler", "sound_tokenizer", "transformer", "vae", "vision_encoder"):
+    # The public Diffusers pipeline does not register the Qwen vision encoder as
+    # a pipeline component; it is saved as a sidecar for transformers/vLLM and
+    # validated below through its required files, weight index, and tensor header.
+    for component in ("scheduler", "sound_tokenizer", "transformer", "vae"):
         assert component in pipeline_config, f"Diffusers model_index.json is missing component {component!r}"
 
     model_config = json.loads((model_dir / "config.json").read_text())

--- a/tests/launch_regression_test.py
+++ b/tests/launch_regression_test.py
@@ -73,6 +73,7 @@ That prints the captured series for each spec; copy them into the matching
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -506,6 +507,98 @@ def _load_st_tensor(directory: Path, key: str, weight_map: dict[str, str]):
         return f.get_tensor(key)
 
 
+def _safetensors_keys(path: Path) -> set[str]:
+    """Read tensor names from a safetensors header without materializing weights."""
+    from safetensors import safe_open
+
+    assert path.is_file() and path.stat().st_size > 8, f"safetensors file missing or empty: {path}"
+    with safe_open(str(path), framework="pt") as f:
+        return set(f.keys())
+
+
+def _assert_diffusers_export_complete(model_dir: Path, reference_dir: Path) -> None:
+    """Validate the component files and safetensors indexes of a Nano Diffusers export."""
+    required_files = (
+        "checkpoint.json",
+        "config.json",
+        "model_index.json",
+        "model.safetensors.index.json",
+        "scheduler/scheduler_config.json",
+        "sound_tokenizer/config.json",
+        "sound_tokenizer/diffusion_pytorch_model.safetensors",
+        "tokenizer_config.json",
+        "transformer/config.json",
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "vae/config.json",
+        "vae/diffusion_pytorch_model.safetensors",
+        "vision_encoder/config.json",
+        "vision_encoder/model.safetensors",
+    )
+    for rel_path in required_files:
+        path = model_dir / rel_path
+        assert path.is_file() and path.stat().st_size > 0, f"Diffusers export missing or empty: {path}"
+
+    pipeline_config = json.loads((model_dir / "model_index.json").read_text())
+    assert pipeline_config["_class_name"] == "Cosmos3OmniPipeline"
+    for component in ("scheduler", "sound_tokenizer", "transformer", "vae", "vision_encoder"):
+        assert component in pipeline_config, f"Diffusers model_index.json is missing component {component!r}"
+
+    model_config = json.loads((model_dir / "config.json").read_text())
+    assert model_config["architectures"] == ["Cosmos3ForConditionalGeneration"]
+    assert model_config["model_type"] == "cosmos3_omni"
+    assert isinstance(model_config.get("model"), dict) and model_config["model"]
+
+    top_index = json.loads((model_dir / "model.safetensors.index.json").read_text())
+    top_weight_map: dict[str, str] = top_index["weight_map"]
+    assert top_weight_map, "top-level Diffusers safetensors index has no tensors"
+    assert top_index.get("metadata", {}).get("total_size", 0) > 0
+
+    reference_index = json.loads((reference_dir / "model.safetensors.index.json").read_text())
+    assert top_weight_map == reference_index["weight_map"]
+    assert {str(path.relative_to(model_dir)) for path in model_dir.rglob("*.safetensors")} == {
+        str(path.relative_to(reference_dir)) for path in reference_dir.rglob("*.safetensors")
+    }
+
+    indexed_files = set(top_weight_map.values())
+    assert indexed_files, "top-level Diffusers safetensors index references no files"
+    expected_indexed_files = {
+        f"transformer/{path.name}" for path in (model_dir / "transformer").glob("*.safetensors")
+    }
+    expected_indexed_files.add("vision_encoder/model.safetensors")
+    assert indexed_files == expected_indexed_files
+    indexed_tensor_names: set[str] = set()
+    for rel_path in sorted(indexed_files):
+        path = model_dir / rel_path
+        expected_names = {name for name, filename in top_weight_map.items() if filename == rel_path}
+        actual_names = _safetensors_keys(path)
+        assert actual_names == expected_names, (
+            f"top-level index/header mismatch for {rel_path}: "
+            f"missing={sorted(expected_names - actual_names)[:10]}, "
+            f"extra={sorted(actual_names - expected_names)[:10]}"
+        )
+        indexed_tensor_names.update(actual_names)
+    assert indexed_tensor_names == set(top_weight_map)
+
+    transformer_index = json.loads(
+        (model_dir / "transformer/diffusion_pytorch_model.safetensors.index.json").read_text()
+    )
+    transformer_weight_map: dict[str, str] = transformer_index["weight_map"]
+    top_transformer_weight_map = {
+        name: filename.removeprefix("transformer/")
+        for name, filename in top_weight_map.items()
+        if filename.startswith("transformer/")
+    }
+    assert transformer_weight_map == top_transformer_weight_map
+    assert set(transformer_weight_map.values()) == {
+        path.name for path in (model_dir / "transformer").glob("*.safetensors")
+    }
+
+    assert _safetensors_keys(model_dir / "vision_encoder/model.safetensors")
+    assert _safetensors_keys(model_dir / "vae/diffusion_pytorch_model.safetensors")
+    assert _safetensors_keys(model_dir / "sound_tokenizer/diffusion_pytorch_model.safetensors")
+    assert not list(model_dir.rglob("*.distcp")), "Diffusers export unexpectedly contains DCP shards"
+
+
 # --- tests -------------------------------------------------------------------
 
 
@@ -667,9 +760,10 @@ if MAX_GPUS == 4:
         # ``vision_encoder/`` source bit-for-bit, and a non-trivial subset differs
         # from stock Qwen3-VL (so (2) actually distinguishes a converted tower
         # from a stock one — the vision-drop regression).
+        from safetensors import safe_open
+
         from cosmos_framework.inference.args import OmniSetupOverrides
         from cosmos_framework.inference.common.args import CheckpointOverrides
-        from safetensors import safe_open
 
         nano_dir = Path(
             CheckpointOverrides(checkpoint_path="Cosmos3-Nano")
@@ -719,6 +813,47 @@ if MAX_GPUS == 4:
             assert got.shape != stock.shape or not torch.equal(got, stock), (
                 f"LM tensor {k} still equals stock Qwen3-VL (not converted from Cosmos3-Nano)"
             )
+
+    @pytest.mark.level(2)
+    @pytest.mark.gpus(4)
+    def test_convert_model_to_diffusers_exports_complete_nano(
+        tmp_path: Path, h100_inputs: dict[str, str], request: pytest.FixtureRequest
+    ) -> None:
+        """Convert the staged Nano DCP and validate the complete Diffusers output layout and indexes."""
+        del h100_inputs  # The fixture stages and exports BASE_CHECKPOINT_PATH for the subprocess.
+        checkpoint_path = Path(os.environ["BASE_CHECKPOINT_PATH"])
+        config_path = checkpoint_path / "model/config.json"
+        assert config_path.is_file(), f"Nano DCP config is missing: {config_path}"
+        reference_dir = Path(_hf_download(["nvidia/Cosmos3-Nano"]))
+
+        out_dir = tmp_path / "Cosmos3-Nano-Diffusers"
+
+        def cleanup_output() -> None:
+            shutil.rmtree(out_dir, ignore_errors=True)
+            assert not out_dir.exists(), f"failed to clean Diffusers test output: {out_dir}"
+
+        request.addfinalizer(cleanup_output)
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f".:{env.get('PYTHONPATH', '')}"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "cosmos_framework.scripts.convert_model_to_diffusers",
+                "--checkpoint-path",
+                str(checkpoint_path),
+                "--config-file",
+                str(config_path),
+                "--no-use-ema-weights",
+                "-o",
+                str(out_dir),
+            ],
+            cwd=str(REPO_ROOT),
+            env=env,
+        )
+        assert result.returncode == 0, f"convert_model_to_diffusers failed with exit code {result.returncode}"
+        _assert_diffusers_export_complete(out_dir, reference_dir)
 
 
 if MAX_GPUS == 8:


### PR DESCRIPTION
## Summary

- support Cosmos3 checkpoints with optional action and sound generation
- support current and legacy AVAE/tokenizer layouts and framework-native VLM config layouts
- make language-model remapping reject collisions and exclude visual weights from the text transformer
- support both legacy and current action projection module names
- add `--skip-vision-encoder` and make `--config-only` work with an empty output directory
- generate a top-level safetensors index that matches the files actually exported
- keep the converter implementation aligned with the corresponding Cosmos3 package implementation, apart from repository-specific imports and licensing
- add a GPU CI regression that converts the staged Nano DCP, validates the complete Diffusers output against the public Nano reference indexes, and always removes the generated output

## Validation

- converted a Cosmos3-Nano DCP checkpoint to a complete Diffusers checkpoint
- verified all 10 exported safetensors files byte-for-byte against `nvidia/Cosmos3-Nano`
- verified the unified index contains 1,165 tensors with no dangling file references
- loaded the output with `Cosmos3OmniPipeline` and ran one-step video-plus-sound inference with finite outputs
- verified pytest collection selects the new Nano Diffusers conversion test in the generator GPU workflow
- Ruff check, `py_compile`, YAML parse, and `git diff --check` pass
