### PR TITLE
feat: wire MXFP8/NVFP4 quantization into inference CLI

### DIFF
--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -603,6 +603,38 @@ ParallelismPreset = Literal["throughput", "latency"]
 CfgpSize = Annotated[int, pydantic.Field(ge=1, le=2)]
 CompiledRegion = Literal["all", "language"]
 
+# Low-precision quantization method to apply to the model at load time.
+# One of ``mxfp8`` / ``nvfp4``, or ``None`` (default) to disable.
+# Routed to the VFM model loader, which selects an FSDP-compatible
+# (module-swap) path when sharded (``dp_shard_size > 1``) and an in-place
+# path when replicated (``dp_shard_size == 1``). Note ``mxfp8`` / ``nvfp4``
+# are only supported on the replicated path.
+QuantizationMethod = Literal["mxfp8", "nvfp4"]
+
+
+class QuantizationArgs(ArgsBase):
+    """Low-precision quantization arguments applied to the model at load time."""
+
+    quantization_method: QuantizationMethod | None
+    quantization_include_regex: list[str]
+    quantization_exclude_regex: list[str]
+
+
+class QuantizationOverrides(OverridesBase):
+    quantization_method: QuantizationMethod | None = None
+    """Quantization method (``mxfp8`` / ``nvfp4``), or ``None`` to disable.
+
+    Post-training quantization (PTQ) is applied in-place to the model at load
+    time. Only supported on Blackwell architectures and when FSDP sharding is disabled.
+    """
+    quantization_include_regex: list[str] = ["language_model.model.layers"]
+    """Regexes matched against module FQNs; a Linear is quantized only if it matches one (empty = all)."""
+    quantization_exclude_regex: list[str] = pydantic.Field(default_factory=list)
+    """Regexes matched against module FQNs; a Linear is skipped if it matches any."""
+
+    def build_quantization(self) -> QuantizationArgs:
+        return self._build(QuantizationArgs)
+
 
 class ParallelismArgs(ArgsBase):
     """Parallelism arguments."""
@@ -702,7 +734,7 @@ class GuardrailOverrides(OverridesBase):
     """Offload guardrail models to CPU."""
 
 
-class SetupArgs(ABC, CheckpointArgs, ParallelismArgs, GuardrailArgs):
+class SetupArgs(ABC, CheckpointArgs, ParallelismArgs, QuantizationArgs, GuardrailArgs):
     output_dir: ResolvedPath
     keep_going: bool
     skip_invalid_samples: bool
@@ -737,7 +769,7 @@ class SetupArgs(ABC, CheckpointArgs, ParallelismArgs, GuardrailArgs):
         return cls.model_fields["variant"].default
 
 
-class SetupOverrides(ABC, CheckpointOverrides, ParallelismOverrides, GuardrailOverrides):
+class SetupOverrides(ABC, CheckpointOverrides, ParallelismOverrides, QuantizationOverrides, GuardrailOverrides):
     """Inference setup arguments."""
 
     output_dir: Annotated[ResolvedPath | None, tyro.conf.arg(aliases=("-o",))] = None

--- a/cosmos_framework/inference/common/public_model_config.py
+++ b/cosmos_framework/inference/common/public_model_config.py
@@ -37,6 +37,7 @@ _TYPE_ALIASES = {
     "projects.cosmos3.vfm.configs.base.defaults.model_config.RectifiedFlowInferenceConfig": "rectified_flow_inference_config",
     "projects.cosmos3.vfm.configs.base.defaults.model_config.RectifiedFlowTrainingConfig": "rectified_flow_training_config",
     "projects.cosmos3.vfm.configs.base.defaults.parallelism.ParallelismConfig": "parallelism_config",
+    "projects.cosmos3.vfm.configs.base.defaults.quantization.QuantizationConfig": "quantization_config",
     "projects.cosmos3.vfm.configs.base.defaults.vlm.PretrainedWeightsConfig": "pretrained_weights_config",
     "projects.cosmos3.vfm.configs.base.defaults.vlm.VLMConfig": "vlm_config",
 }

--- a/cosmos_framework/inference/inference.py
+++ b/cosmos_framework/inference/inference.py
@@ -23,6 +23,7 @@ from typing_extensions import Self
 
 from cosmos_framework.configs.base.defaults.compile import CompileConfig
 from cosmos_framework.configs.base.defaults.parallelism import ParallelismConfig
+from cosmos_framework.configs.base.defaults.quantization import QuantizationConfig
 from cosmos_framework.inference.args import (
     ModelMode,
     NegativeMetadataMode,
@@ -1055,6 +1056,14 @@ class OmniInference(Inference):
             compile_dynamic=setup_args.compile_dynamic,
         )
 
+    @classmethod
+    def _get_quantization_config(cls, setup_args: SetupArgs) -> QuantizationConfig:
+        return QuantizationConfig(
+            method=setup_args.quantization_method,
+            include_regex=list(setup_args.quantization_include_regex),
+            exclude_regex=list(setup_args.quantization_exclude_regex),
+        )
+
     @override
     @classmethod
     def _create(cls, setup_args: SetupArgs, **kwargs: Any) -> Self:
@@ -1064,6 +1073,7 @@ class OmniInference(Inference):
         sampler_override = setup_args.sampler
         parallelism_config = cls._get_parallelism_config(setup_args)
         compile_config = cls._get_compile_config(setup_args)
+        quantization_config = cls._get_quantization_config(setup_args)
         if setup_args.checkpoint_type == CheckpointType.DCP and setup_args.config_file_type == ConfigFileType.MODULE:
             from cosmos_framework.inference.common.config import save_config
             from cosmos_framework.utils.generator.model_loader import load_model_from_checkpoint
@@ -1081,6 +1091,7 @@ class OmniInference(Inference):
                 credential_path=setup_args.credential_path or None,
                 parallelism_config=attrs.asdict(parallelism_config),
                 compile_config=attrs.asdict(compile_config),
+                quantization_config=attrs.asdict(quantization_config),
                 load_ema_to_reg=setup_args.use_ema_weights,
                 experiment_opts=[
                     *setup_args.experiment_overrides,
@@ -1130,6 +1141,7 @@ class OmniInference(Inference):
                 config=config,
                 parallelism_config=parallelism_config,
                 compile_config=compile_config,
+                quantization_config=quantization_config,
             ).model
             if model.config.rectified_flow_inference_config.scheduler_type != sampler_override:
                 model.config.rectified_flow_inference_config.scheduler_type = sampler_override

--- a/cosmos_framework/inference/model.py
+++ b/cosmos_framework/inference/model.py
@@ -34,6 +34,7 @@ from typing_extensions import TYPE_CHECKING, assert_never
 
 from cosmos_framework.configs.base.defaults.compile import CompileConfig
 from cosmos_framework.configs.base.defaults.parallelism import ParallelismConfig
+from cosmos_framework.configs.base.defaults.quantization import QuantizationConfig
 from cosmos_framework.inference.common.args import CheckpointType
 from cosmos_framework.inference.common.checkpoints import register_checkpoints
 from cosmos_framework.inference.common.config import structure_config, undo_config_dict_replacements, unstructure_config
@@ -416,6 +417,16 @@ class Cosmos3OmniConfig(transformers.PretrainedConfig):
             return
         self.model.setdefault("config", {})["compile"] = unstructure_config(CompileConfig(**value))
 
+    @property
+    def quantization(self) -> dict:
+        return self.model.get("config", {}).get("quantization", {})
+
+    @quantization.setter
+    def quantization(self, value: dict | None):
+        if value is None:
+            return
+        self.model.setdefault("config", {})["quantization"] = unstructure_config(QuantizationConfig(**value))
+
 
 class Cosmos3OmniModel(transformers.PreTrainedModel):
     config_class = Cosmos3OmniConfig  # type: ignore
@@ -448,6 +459,7 @@ class Cosmos3OmniModel(transformers.PreTrainedModel):
         config: Cosmos3OmniConfig | None = None,
         parallelism_config: ParallelismConfig | None = None,
         compile_config: CompileConfig | None = None,
+        quantization_config: QuantizationConfig | None = None,
     ):
         if config is None:
             config = Cosmos3OmniConfig.from_pretrained(checkpoint_path)
@@ -455,8 +467,11 @@ class Cosmos3OmniModel(transformers.PreTrainedModel):
             parallelism_config = ParallelismConfig()
         if compile_config is None:
             compile_config = CompileConfig()
+        if quantization_config is None:
+            quantization_config = QuantizationConfig()
         config.parallelism = attrs.asdict(parallelism_config)
         config.compile = attrs.asdict(compile_config)
+        config.quantization = attrs.asdict(quantization_config)
         model = cls(config)
         checkpoint_type = CheckpointType.from_path(checkpoint_path)
         match checkpoint_type:


### PR DESCRIPTION
## Summary

Ports the inference-CLI plumbing from imaginaire4 **MR 10201** (`Inference optimizations [4/n]: MXFP8 / NVFP4 PTQ`) that was missing on this side.

The quantization **backend** was already synced (via the 2026-07-10 release): `QuantizationConfig` (`configs/base/defaults/quantization.py`), `apply_quantization_inplace` (`utils/generator/quantization.py`), and the `model_loader.py` hook. But the user-facing `OmniInference` entrypoint was never wired, so `--quantization-method` had no effect. This PR connects them.

The missing pieces mapped exactly to MR 10201's `packages/cosmos3/cosmos3/*` files (→ `cosmos_framework/inference/*`); the `projects/cosmos3/*` files were already in.

## Changes

- **`inference/common/args.py`** — add `QuantizationMethod` / `QuantizationArgs` / `QuantizationOverrides`; mix them into `SetupArgs` / `SetupOverrides`. Fields flow through `build_setup`'s `model_dump → model_validate` (same as guardrails), so no extra build call is needed.
- **`inference/model.py`** — add `Cosmos3OmniConfig.quantization` property + setter and thread `quantization_config` through `from_pretrained_dcp`. Uses the **local** direct-construction style `unstructure_config(QuantizationConfig(**value))` rather than upstream's `LazyCall` wrapper, matching the sibling `parallelism`/`compile` setters in this repo.
- **`inference/inference.py`** — add `_get_quantization_config` and pass it into **both** `_create` branches (`load_model_from_checkpoint` and `from_pretrained_dcp`).

## Effect

- **Standard experiment DCP path** (`load_model_from_checkpoint`): quantization applied end-to-end via `apply_quantization_inplace`. ✅
- **HF `from_pretrained_dcp` path**: stores `config.quantization` without an apply hook — **matches upstream MR behavior** (not a regression introduced here).
- Only supported on Blackwell + replicated inference (no FSDP sharding); guarded by the existing `model_loader.py` DP-shard check.

## Not included

- `websocket_policy_server/serve_policy.py` + README from the MR — that action-eval subtree is not present in this repo.
- The MR's cosmetic blank-line change in `packages/cosmos3/cosmos3/args.py`.

## Verification

- `py_compile` passes on all three files.
- Load-bearing pydantic logic verified in-container (isolated replica): defaults, mutable-list-default isolation, `build_quantization`, `Literal` rejection of invalid methods, MRO/inheritance, and `SetupOverrides → SetupArgs` field flow — all assertions pass.
- Full module import not exercised: cosmos-framework requires Python ≥3.12 while the available i4 container env is 3.10; needs the cosmos-framework 3.13 venv to import the real module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)