### PR TITLE
Report MFU on B300 in VLMTokensPerSec

### DIFF
--- a/cosmos_framework/callbacks/tokens_per_sec.py
+++ b/cosmos_framework/callbacks/tokens_per_sec.py
@@ -235,6 +235,8 @@ class VLMTokensPerSec(EveryN):
         if not torch.cuda.is_available():
             return None
         name = torch.cuda.get_device_name()
+        if "B300" in name or "GB300" in name:
+            return 2.25e15  # HGX B300 dense BF16: 36 PFLOPS sparse / 2 / 8 GPUs (datasheet)
         if any(k in name for k in ("B200", "GB200", "Blackwell")):
             return 2.45e15  # GB200 NVL72 dense BF16 ~2.45 PFLOP/s/GPU (no sparsity)
         if "H200" in name or "H100" in name:


### PR DESCRIPTION
torch.cuda.get_device_name() returns 'NVIDIA B300 SXM6 AC', which the device->peak-FLOPs table in VLMTokensPerSec._resolve_peak_flops did not match, so useful_mfu was skipped ("unknown device ... MFU not reported").

Add a B300/GB300 branch returning 2.25e15 (HGX B300 dense BF16 per the NVIDIA datasheet: 36 PFLOPS sparse / 2 / 8 GPUs = 2.25 PFLOP/s/GPU), placed ahead of the B200 branch since the peaks differ.