### PR TITLE
feat: support Cosmos3-Edge-Policy-DROID in robolab policy server

### DIFF
--- a/cosmos_framework/data/generator/processors/__init__.py
+++ b/cosmos_framework/data/generator/processors/__init__.py
@@ -104,6 +104,14 @@ def build_processor(
     bucket: Optional[str] = None,
     cache_dir: Optional[str] = None,
 ):
+    # The Edge policy checkpoint bundles a custom Cosmos3EdgeProcessor with no
+    # loadable processor code (no auto_map / remote code), so it cannot be built
+    # via AutoProcessor. Source the identical processor from the Edge reasoner
+    # repo it was post-trained from -- this matches how internal training sources
+    # the Nemotron-3-Dense-VL processor (never from the policy checkpoint).
+    if "Cosmos3-Edge-Policy-DROID" in tokenizer_type:
+        tokenizer_type = "nvidia/Cosmos3-Edge-Reasoner"
+
     # Local artifact path: source the processor from a bundled directory
     # (e.g. the top level of nvidia/Cosmos3-Nano, which ships its own
     # preprocessor_config.json, tokenizer.json, etc). Avoids the redundant

--- a/cosmos_framework/inference/common/public_model_config.py
+++ b/cosmos_framework/inference/common/public_model_config.py
@@ -19,6 +19,8 @@ _PUBLIC_VFM_URI_PREFIX = "cosmos3://vfm/"
 _TARGET_ALIASES = {
     "projects.cosmos3.vfm.configs.base.defaults.vlm.create_qwen2_tokenizer_with_download": "create_qwen2_tokenizer_with_download",
     "projects.cosmos3.vfm.configs.base.defaults.vlm.create_vlm_config": "create_vlm_config",
+    "projects.cosmos3.vfm.models.mot.unified_mot.Nemotron3DenseVLMoTConfig.from_json_file": "nemotron3_dense_vl_mot_config_from_json_file",
+    "projects.cosmos3.vfm.models.mot.unified_mot.Nemotron3DenseVLTextForCausalLM": "nemotron3_dense_vl_text_for_causal_lm",
     "projects.cosmos3.vfm.models.mot.unified_mot.Qwen3VLMoTConfig.from_json_file": "qwen3_vl_mot_config_from_json_file",
     "projects.cosmos3.vfm.models.mot.unified_mot.Qwen3VLTextForCausalLM": "qwen3_vl_text_for_causal_lm",
     "projects.cosmos3.vfm.models.omni_mot_model.OmniMoTModel": "omni_mot_model",

--- a/cosmos_framework/scripts/action_policy_server_robolab.py
+++ b/cosmos_framework/scripts/action_policy_server_robolab.py
@@ -25,6 +25,7 @@ from cosmos_framework.inference.common.init import init_script
 
 init_script()
 
+import json
 import socket
 import threading
 from dataclasses import dataclass
@@ -77,6 +78,8 @@ _DEFAULT_HF_REVISION = "main"
 _ROBOLAB_POLICY_HF_REPOSITORIES = {
     "Cosmos3-Nano-Policy-DROID": "nvidia/Cosmos3-Nano-Policy-DROID",
     "nvidia/Cosmos3-Nano-Policy-DROID": "nvidia/Cosmos3-Nano-Policy-DROID",
+    "Cosmos3-Edge-Policy-DROID": "nvidia/Cosmos3-Edge-Policy-DROID",
+    "nvidia/Cosmos3-Edge-Policy-DROID": "nvidia/Cosmos3-Edge-Policy-DROID",
 }
 
 ActionSpace = Literal["joint_pos", "midtrain"]
@@ -352,6 +355,8 @@ class RobolabServerArgs(pydantic.BaseModel):
     """Whether the first action row contains the current state."""
     history_length: int = 1
     """State/history action rows to trim from the generated action output."""
+    format_prompt_as_json: bool | None = None
+    """Serve prompts as structured JSON (matching training ``format_prompt_as_json``)."""
 
 
 class RobolabPolicyService:
@@ -453,9 +458,17 @@ class RobolabPolicyService:
 
         if dataset_config is None or dataset_entry is None:
             log.warning(
-                "[robolab-policy-server] no training action dataset config found; using default ActionTransformPipeline"
+                "[robolab-policy-server] no training action dataset config found; using default "
+                f"ActionTransformPipeline (format_prompt_as_json={bool(args.format_prompt_as_json)})"
             )
-            return ActionTransformPipeline(max_action_dim=max_action_dim, cfg_dropout_rate=0.0), inferred
+            return (
+                ActionTransformPipeline(
+                    max_action_dim=max_action_dim,
+                    cfg_dropout_rate=0.0,
+                    format_prompt_as_json=bool(args.format_prompt_as_json),
+                ),
+                inferred,
+            )
 
         if action_dataset_config is not None:
             chunk_length = getattr(action_dataset_config, "chunk_length", None)
@@ -478,6 +491,9 @@ class RobolabPolicyService:
             dataset_config.cfg_dropout_rate = 0.0
 
         dataset_entry.dataset = {"_target_": f"{__name__}._DummyDataset"}
+
+        if args.format_prompt_as_json is not None:
+            dataset_config.format_prompt_as_json = bool(args.format_prompt_as_json)
 
         wrapped_dataset = instantiate(dataset_config)
         return wrapped_dataset.transform, inferred
@@ -552,7 +568,10 @@ class RobolabPolicyService:
         }
         if history_action is not None:
             sample["history_action"] = history_action
-        return self._transform(sample, self.cfg.resolution)
+        sample = self._transform(sample, self.cfg.resolution)
+        if isinstance(sample.get("ai_caption"), dict):
+            sample["ai_caption"] = json.dumps(sample["ai_caption"])
+        return sample
 
     def infer(self, obs: dict[str, Any]) -> dict[str, Any]:
         sample = self._build_sample(obs)

--- a/cosmos_framework/utils/checkpoint_db.py
+++ b/cosmos_framework/utils/checkpoint_db.py
@@ -455,6 +455,16 @@ def download_checkpoint_v2(checkpoint_uri: str, *, check_exists: bool = True) ->
         return checkpoint_uri
     if checkpoint_uri.startswith("hf://"):
         return _download_hf_checkpoint(checkpoint_uri)
+    # Bare relative registry path produced by Cosmos3-Edge-Policy-DROID. Its checkpoint
+    # conversion exports the Wan2.2 VAE tokenizer with an empty ``bucket_name`` (Nano
+    # exports ``bucket_name="bucket"``), so ``Wan2pt2VAEInterface`` forwards the raw relative
+    # ``vae_path`` ("pretrained/tokenizers/video/wan2pt2/Wan2.2_VAE.pth") here instead of the
+    # ``s3://bucket/...`` key. Re-form that key so it resolves through the registry and
+    # auto-downloads from HF, matching Nano's path. Local files still take precedence (below).
+    if "://" not in checkpoint_uri and not os.path.exists(checkpoint_uri):
+        registered = CheckpointConfig.maybe_from_uri(sanitize_uri(f"s3://bucket/{checkpoint_uri}"))
+        if registered is not None:
+            return registered.download()
     if check_exists and not os.path.exists(checkpoint_uri):
         raise ValueError(f"Checkpoint path {checkpoint_uri} does not exist.")
     return checkpoint_uri


### PR DESCRIPTION
### Summary

Enables serving the new **Cosmos3-Edge-Policy-DROID** checkpoint through the robolab action policy server. The Edge policy was post-trained from Cosmos3-Edge (Nemotron-3-Dense-VL backbone) and differs from the existing Nano policy in its processor, model config, tokenizer export, and prompt formatting — this MR wires up each of those differences so the checkpoint runs end-to-end.

### Changes

- **`data/generator/processors/__init__.py`** — Build the Edge processor from `nvidia/Cosmos3-Edge-Reasoner`. The policy checkpoint bundles a custom `Cosmos3EdgeProcessor` with no loadable processor code (no `auto_map` / remote
  code), so it can't be built via `AutoProcessor`. Sourcing it from the reasoner repo it was post-trained from mirrors how internal training sources the Nemotron-3-Dense-VL processor.
- **`inference/common/public_model_config.py`** — Register the `Nemotron3DenseVLMoTConfig.from_json_file` and `Nemotron3DenseVLTextForCausalLM` target aliases used by the Edge policy.
- **`scripts/action_policy_server_robolab.py`** — Add the Edge policy HF repo mapping, and a new `format_prompt_as_json` server arg that serves prompts as structured JSON to match training. When the transform emits `ai_caption` as a dict, it's JSON-encoded before serving.
- **`utils/checkpoint_db.py`** — Re-form the bare relative Wan2.2 VAE path exported by the Edge checkpoint into an `s3://bucket/...` registry key. The Edge conversion exports the VAE tokenizer with an empty `bucket_name` (Nano exports `bucket_name="bucket"`), so the raw relative `vae_path` reaches the downloader instead of a registry key; re-forming it lets the VAE resolve through the registry and auto-download from HF, matching Nano's path. Local files still take precedence.
