### PR TITLE
Added the num-iteration flag and cleaned up benchmark timing

### DIFF
--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -765,6 +765,7 @@ class SetupArgs(ABC, CheckpointArgs, ParallelismArgs, QuantizationArgs, Guardrai
     profile: bool
     benchmark: bool
     warmup: pydantic.NonNegativeInt
+    num_iterations: pydantic.PositiveInt
     max_model_len: pydantic.PositiveInt | None
     max_num_seqs: pydantic.PositiveInt | None
 
@@ -811,6 +812,8 @@ class SetupOverrides(ABC, CheckpointOverrides, ParallelismOverrides, Quantizatio
     """If set, measures and reports inference runtime (disables tqdm)."""
     warmup: pydantic.NonNegativeInt = 0
     """Number of warmup generations before each sample."""
+    num_iterations: pydantic.PositiveInt = 1
+    """Number of benchmark generations to run after warmup."""
     max_model_len: pydantic.PositiveInt | None = None
     """Maximum total tokens per batch.  When set, samples are packed into
     batches by token count."""
@@ -819,7 +822,8 @@ class SetupOverrides(ABC, CheckpointOverrides, ParallelismOverrides, Quantizatio
     batches by number of sequences."""
 
     def _build_setup(self):
-        pass
+        if self.num_iterations > 1 and not self.benchmark:
+            raise ValueError("num_iterations > 1 requires benchmark=True")
 
     @abstractmethod
     def build_setup(self) -> SetupArgs:

--- a/cosmos_framework/inference/common/args_test.py
+++ b/cosmos_framework/inference/common/args_test.py
@@ -7,12 +7,19 @@ from pathlib import Path
 
 import pytest
 
-from cosmos_framework.inference.args import DEFAULT_CHECKPOINT, DEFAULT_CHECKPOINT_NAME
+from cosmos_framework.inference.args import DEFAULT_CHECKPOINT, DEFAULT_CHECKPOINT_NAME, OmniSetupOverrides
 from cosmos_framework.inference.common.args import CheckpointConfig, CheckpointOverrides, CheckpointType, download_file
 
 CHECKPOINTS: dict[str, CheckpointConfig] = {
     DEFAULT_CHECKPOINT_NAME: DEFAULT_CHECKPOINT,
 }
+
+
+def test_num_iterations_requires_benchmark() -> None:
+    overrides = OmniSetupOverrides.model_construct(benchmark=False, num_iterations=2)
+
+    with pytest.raises(ValueError, match="num_iterations > 1 requires benchmark=True"):
+        overrides._build_setup()
 
 
 def test_checkpoint_type_from_diffusers_layout(tmp_path: Path) -> None:

--- a/cosmos_framework/inference/common/inference.py
+++ b/cosmos_framework/inference/common/inference.py
@@ -119,7 +119,11 @@ class Inference(ABC):
 
     @abstractmethod
     def generate_batch(
-        self, sample_args_list: Sequence[SampleArgs], data_batch: dict[str, Any], *, warmup: bool = False
+        self,
+        sample_args_list: Sequence[SampleArgs],
+        data_batch: dict[str, Any],
+        *,
+        save_outputs: bool = True,
     ) -> list[SampleOutputs]:
         """Generate a batch of samples."""
 
@@ -157,12 +161,59 @@ class Inference(ABC):
             else:
                 profiler = contextlib.nullcontext()
 
+            # Spend the *first* warmup pass on a real save pass
+            # so the one-time output-persistence cost (dir creation, guardrail
+            # lazy-load, first ffmpeg spawn) is paid before measurement begins.
+            # Profile the final warmup pass after those one-time costs have been
+            # paid. Every measured iteration is then pure generate+decode with
+            # uniform timing, and the artifact is produced from the deterministic,
+            # identical-seed first warmup pass. When there is no warmup budget,
+            # save on the first measured iteration and profile the final one.
+            #
+            # Note on warmup counts:
+            #   * warmup >= 2: the first pass saves, intermediate passes are
+            #     throwaway dry-runs, and the final pass is profiled without saving.
+            #   * warmup == 1: the sole slot is both the save and profile pass.
+            profile = self.setup_args.profile
+            save_in_warmup = self.setup_args.warmup > 0
+            profile_in_warmup = profile and save_in_warmup
             with self._get_timer_context("warmup"):
-                for _ in range(self.setup_args.warmup):
-                    with self._get_timer(f"{self.__class__.__name__}.generate_batch"):
-                        self.generate_batch(sample_args_batch, data_batch, warmup=True)
-            with self._get_timer(f"{self.__class__.__name__}.generate_batch"), profiler:
-                sample_outputs.extend(self.generate_batch(sample_args_batch, data_batch))
+                for i_warmup in range(self.setup_args.warmup):
+                    is_save_pass = i_warmup == 0
+                    is_profile_pass = profile_in_warmup and i_warmup == self.setup_args.warmup - 1
+                    profiler_context = profiler if is_profile_pass else contextlib.nullcontext()
+                    with self._get_timer(f"{self.__class__.__name__}.generate_batch"), profiler_context:
+                        warmup_outputs = self.generate_batch(
+                            sample_args_batch,
+                            data_batch,
+                            save_outputs=is_save_pass,
+                        )
+                    if is_save_pass:
+                        sample_outputs.extend(warmup_outputs)
+
+            num_iterations = self.setup_args.num_iterations
+            for i_iteration in range(num_iterations):
+                # If the artifact was already saved during warmup, no measured
+                # iteration saves; otherwise the first measured iteration does.
+                save_outputs = i_iteration == 0 and not save_in_warmup
+                if num_iterations > 1:
+                    log.debug(
+                        f"[{i_batch + 1}] Benchmark iteration {i_iteration + 1}/{num_iterations}",
+                        rank0_only=False,
+                    )
+                # If profiling already ran on the final warmup pass, the measured
+                # loop stays profiler-free. Without a warmup, profile the final
+                # measured iteration separately from the first-iteration save pass.
+                should_profile = i_iteration == num_iterations - 1 and profile and not profile_in_warmup
+                profiler_context = profiler if should_profile else contextlib.nullcontext()
+                with self._get_timer(f"{self.__class__.__name__}.generate_batch"), profiler_context:
+                    batch_outputs = self.generate_batch(
+                        sample_args_batch,
+                        data_batch,
+                        save_outputs=save_outputs,
+                    )
+                if save_outputs:
+                    sample_outputs.extend(batch_outputs)
 
             if self.setup_args.profile and is_rank0():
                 assert isinstance(profiler, torch.profiler.profile)
@@ -192,9 +243,20 @@ class Inference(ABC):
     def get_timer_results(self) -> dict | None:
         if self._timer is None:
             return None
+        # With warmup == 0 and multiple measured iterations, the first
+        # measured iteration is the cold pass and is dropped from the
+        # reported average.
+        drop_first_non_warmup = self.setup_args.benchmark and self.setup_args.warmup == 0
+        average: dict[str, float] = {}
+        for key, values in self._timer.results.items():
+            if not values:
+                continue
+            if drop_first_non_warmup and not key.startswith("[warmup]") and len(values) > 1:
+                values = values[1:]
+            average[key] = sum(values) / len(values)
         return {
             "all": self._timer.results,
-            "average": self._timer.compute_average_results(),
+            "average": average,
         }
 
     def _handle_sample_exception(self, sample_args: SampleArgs, e: Exception) -> SampleOutputs:

--- a/cosmos_framework/inference/common/inference_test.py
+++ b/cosmos_framework/inference/common/inference_test.py
@@ -1,14 +1,183 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
+import contextlib
+from collections.abc import Iterator, Sequence
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Self, cast
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
 
-from cosmos_framework.inference.common.args import GuardrailArgs
-from cosmos_framework.inference.common.inference import GuardrailRunners, _download_on_rank0
+from cosmos_framework.inference.common.args import GuardrailArgs, SampleArgs, SampleOutputs, SetupArgs
+from cosmos_framework.inference.common.inference import GuardrailRunners, Inference, _download_on_rank0
+
+
+class _DummyInference(Inference):
+    calls: list[bool]
+    events: list[str] | None
+
+    @property
+    def model_config(self) -> dict[str, Any]:
+        return {}
+
+    @classmethod
+    def _create(cls, setup_args: SetupArgs, /, **kwargs: Any) -> Self:
+        instance = cls(setup_args=setup_args, model=Mock(), **kwargs)
+        instance.calls = []
+        instance.events = None
+        return instance
+
+    def create_batches(
+        self, sample_args_list: Sequence[SampleArgs]
+    ) -> Iterator[tuple[list[SampleArgs], dict[str, Any]]]:
+        yield list(sample_args_list), {"payload": [1]}
+
+    def generate_batch(
+        self,
+        sample_args_list: Sequence[SampleArgs],
+        data_batch: dict[str, Any],
+        *,
+        save_outputs: bool = True,
+    ) -> list[SampleOutputs]:
+        self.calls.append(save_outputs)
+        if self.events is not None:
+            self.events.append(f"generate-save-{save_outputs}")
+        return [SampleOutputs(args={"name": "sample"})] if save_outputs else []
+
+
+def _setup_args(**overrides: Any) -> SetupArgs:
+    values = {
+        "benchmark": True,
+        "warmup": 0,
+        "num_iterations": 1,
+        "profile": False,
+        "guardrails": False,
+        "keep_going": False,
+    }
+    values.update(overrides)
+    return cast(SetupArgs, SimpleNamespace(**values))
+
+
+def _sample_args() -> list[SampleArgs]:
+    return cast(list[SampleArgs], [SimpleNamespace(name="sample")])
+
+
+def test_benchmark_runs_warmups_and_requested_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference.common import inference as inference_module
+
+    monkeypatch.setattr(inference_module, "sync_distributed_errors", contextlib.nullcontext)
+    pipe = _DummyInference.create(_setup_args(warmup=2, num_iterations=3))
+
+    outputs = pipe.generate(_sample_args())
+
+    assert len(outputs) == 1
+    assert pipe.calls == [True, False, False, False, False]
+    timer_results = pipe.get_timer_results()
+    assert timer_results is not None
+    assert len(timer_results["all"]["[warmup] _DummyInference.generate_batch"]) == 2
+    assert len(timer_results["all"]["_DummyInference.generate_batch"]) == 3
+
+
+def test_benchmark_saves_first_warmup_and_profiles_last(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference.common import inference as inference_module
+
+    events: list[str] = []
+
+    class FakeProfiler:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            events.append("profile-enter")
+            return self
+
+        def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+            events.append("profile-exit")
+
+    monkeypatch.setattr(inference_module, "sync_distributed_errors", contextlib.nullcontext)
+    monkeypatch.setattr(inference_module, "is_rank0", lambda: False)
+    monkeypatch.setattr(inference_module.torch.profiler, "profile", FakeProfiler)
+    pipe = _DummyInference.create(_setup_args(warmup=3, num_iterations=2, profile=True))
+    pipe.events = events
+
+    outputs = pipe.generate(_sample_args())
+
+    assert len(outputs) == 1
+    assert events == [
+        "generate-save-True",
+        "generate-save-False",
+        "profile-enter",
+        "generate-save-False",
+        "profile-exit",
+        "generate-save-False",
+        "generate-save-False",
+    ]
+
+
+def test_benchmark_without_warmup_profiles_final_iteration(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference.common import inference as inference_module
+
+    events: list[str] = []
+
+    class FakeProfiler:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> Self:
+            events.append("profile-enter")
+            return self
+
+        def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+            events.append("profile-exit")
+
+    monkeypatch.setattr(inference_module, "sync_distributed_errors", contextlib.nullcontext)
+    monkeypatch.setattr(inference_module, "is_rank0", lambda: False)
+    monkeypatch.setattr(inference_module.torch.profiler, "profile", FakeProfiler)
+    pipe = _DummyInference.create(_setup_args(num_iterations=3, profile=True))
+    pipe.events = events
+
+    outputs = pipe.generate(_sample_args())
+
+    assert len(outputs) == 1
+    assert events == [
+        "generate-save-True",
+        "generate-save-False",
+        "profile-enter",
+        "generate-save-False",
+        "profile-exit",
+    ]
+
+
+def test_non_benchmark_run_saves_during_first_warmup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference.common import inference as inference_module
+
+    monkeypatch.setattr(inference_module, "sync_distributed_errors", contextlib.nullcontext)
+    pipe = _DummyInference.create(_setup_args(benchmark=False, warmup=2))
+
+    outputs = pipe.generate(_sample_args())
+
+    assert len(outputs) == 1
+    assert pipe.calls == [True, False, False]
+
+
+def test_benchmark_average_drops_cold_first_pass_only_without_warmup() -> None:
+    for warmup, expected_average in [(0, 2.0), (1, 4.0)]:
+        pipe = _DummyInference.create(_setup_args(warmup=warmup, num_iterations=4))
+        assert pipe._timer is not None
+        pipe._timer.results = {
+            "_DummyInference.generate_batch": [10.0, 2.0, 2.0, 2.0],
+            "[warmup] _DummyInference.generate_batch": [12.0, 8.0],
+        }
+
+        results = pipe.get_timer_results()
+
+        assert results is not None
+        assert results["average"]["_DummyInference.generate_batch"] == expected_average
+        assert results["average"]["[warmup] _DummyInference.generate_batch"] == 10.0
+        assert results["all"]["_DummyInference.generate_batch"] == [10.0, 2.0, 2.0, 2.0]
 
 
 def test_download_on_rank0_broadcasts_shared_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/cosmos_framework/inference/inference.py
+++ b/cosmos_framework/inference/inference.py
@@ -1035,18 +1035,17 @@ def create_batches_from_dataset(
 def _finalize_data_batch(data_batch: dict[str, Any], batch_size: int, model: OmniMoTModel) -> dict[str, Any]:
     """Return a finalized + validated copy of *data_batch*.
 
-    All mutations (key renames, tensor → list unbind) are applied to a fresh
-    shallow copy so the caller's input dict is never modified.  This keeps
+    All mutations (key renames, tensor → list unbind, or list-item replacement)
+    are applied to a fresh copy so the caller's input dict is never modified. This keeps
     the "no aliasing" responsibility localized at the single place where the
     mutation happens, instead of forcing every producer of a data dict (e.g.
     seed-expansion fan-out in ``create_batches_from_dataset``, dummy padding
     batches in ``create_batches``) to defensively copy before handing the
     dict to ``generate_batch``.
 
-    Only the top-level dict structure is copied; tensor / list values inside
-    are shared with the input (which is safe because every mutation here is a
-    top-level key rename or value reassignment, never an in-place op on the
-    value itself).
+    The top-level dict and list containers are copied; tensors and other values
+    inside those lists remain shared. Copying each list is necessary because
+    downstream preprocessing replaces video-list items with normalized tensors.
 
     Args:
         data_batch: Input data dict.  Not modified.
@@ -1062,7 +1061,7 @@ def _finalize_data_batch(data_batch: dict[str, Any], batch_size: int, model: Omn
             present, or if the post-finalize caption-list length doesn't
             match ``batch_size``.
     """
-    data_batch = dict(data_batch)
+    data_batch = {key: list(value) if isinstance(value, list) else value for key, value in data_batch.items()}
 
     for old_key, new_key in [
         ("video", model.input_video_key),

--- a/cosmos_framework/inference/inference.py
+++ b/cosmos_framework/inference/inference.py
@@ -1482,7 +1482,11 @@ class OmniInference(Inference):
     @torch.no_grad()
     @override
     def generate_batch(
-        self, sample_args_list: Sequence[SampleArgs], data_batch: dict[str, Any], *, warmup: bool = False
+        self,
+        sample_args_list: Sequence[SampleArgs],
+        data_batch: dict[str, Any],
+        *,
+        save_outputs: bool = True,
     ) -> list[SampleOutputs]:
         assert all(isinstance(sa, OmniSampleArgs) for sa in sample_args_list)
 
@@ -1490,18 +1494,18 @@ class OmniInference(Inference):
         if any(transfer_flags):
             assert all(transfer_flags), "Cannot mix transfer and non-transfer samples in a batch"
             assert len(sample_args_list) == 1, "Batching is not supported for transfer inference"
-            return self._generate_transfer_batch(sample_args_list[0], warmup=warmup)
+            return self._generate_transfer_batch(sample_args_list[0], save_outputs=save_outputs)
 
         reasoner_flags = [cast(OmniSampleArgs, sa).model_mode.is_reasoner for sa in sample_args_list]
         if any(reasoner_flags):
             assert all(reasoner_flags), "Cannot mix reasoner and non-reasoner samples in a batch"
-            return self._generate_reasoner_batch(sample_args_list, data_batch, warmup=warmup)
+            return self._generate_reasoner_batch(sample_args_list, data_batch, save_outputs=save_outputs)
 
         # Process inputs
         try:
-            with sync_distributed_errors():
+            with self._get_timer(f"{self.__class__.__name__}.prepare_inputs"), sync_distributed_errors():
                 for sample_args in sample_args_list:
-                    if self.should_process_sample(sample_args) and not warmup:
+                    if self.should_process_sample(sample_args) and save_outputs:
                         log.debug(f"{sample_args.__class__.__name__}({sample_args})")
                         assert sample_args.output_dir is not None
                         sample_args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -1514,10 +1518,10 @@ class OmniInference(Inference):
                     data_batch=data_batch, batch_size=len(sample_args_list), model=self.model
                 )
         except Exception as e:
+            # Apply the same error policy to warmup and measured passes:
+            # fail fast unless keep_going is enabled.
             return [
-                self._handle_sample_exception(args, e)
-                for args in sample_args_list
-                if self.should_process_sample(args) and not warmup
+                self._handle_sample_exception(args, e) for args in sample_args_list if self.should_process_sample(args)
             ]
 
         # Generate samples
@@ -1703,7 +1707,7 @@ class OmniInference(Inference):
             with self._get_timer(f"{self.model.__class__.__name__}.decode_sound"):
                 outputs["sound"] = [self.model.decode_sound(sound) for sound in outputs.pop("sound")]
 
-        if warmup:
+        if not save_outputs:
             return []
 
         # Save outputs
@@ -1786,13 +1790,18 @@ class OmniInference(Inference):
         return sample_outputs
 
     @torch.no_grad()
-    def _generate_transfer_batch(self, sample_args: OmniSampleArgs, *, warmup: bool = False) -> list[SampleOutputs]:
+    def _generate_transfer_batch(
+        self,
+        sample_args: OmniSampleArgs,
+        *,
+        save_outputs: bool = True,
+    ) -> list[SampleOutputs]:
         """Handle transfer inference using the autoregressive generate_transfer_sample path."""
         from cosmos_framework.inference.transfer import generate_transfer_sample
 
         try:
             with sync_distributed_errors():
-                if self.should_process_sample(sample_args) and not warmup:
+                if self.should_process_sample(sample_args) and save_outputs:
                     log.debug(f"{sample_args.__class__.__name__}({sample_args})")
                     assert sample_args.output_dir is not None
                     sample_args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -1800,13 +1809,13 @@ class OmniInference(Inference):
                     sample_args_file.write_text(sample_args.model_dump_json())
                     log.info(f"Saved sample args to '{sample_args_file}'", rank0_only=False)
         except Exception as e:
-            if self.should_process_sample(sample_args) and not warmup:
+            if self.should_process_sample(sample_args):
                 return [self._handle_sample_exception(sample_args, e)]
             return []
 
         transfer_output = generate_transfer_sample(sample_args=sample_args, model=self.model)
 
-        if warmup:
+        if not save_outputs:
             return []
 
         sample_outputs: list[SampleOutputs] = []
@@ -1859,7 +1868,7 @@ class OmniInference(Inference):
         sample_args_list: Sequence[SampleArgs],
         data_batch: dict[str, Any],
         *,
-        warmup: bool = False,
+        save_outputs: bool = True,
     ) -> list[SampleOutputs]:
         """Reasoner AR text generation. Each prompt writes ``reasoner_text.txt`` and
         ``SampleOutput.content["reasoner_text"]``. Mixing image-conditioned and
@@ -1892,18 +1901,14 @@ class OmniInference(Inference):
         try:
             with sync_distributed_errors():
                 for sa, prompt in zip(sample_args_list, prompts):
-                    if self.should_process_sample(sa) and not warmup:
+                    if self.should_process_sample(sa) and save_outputs:
                         log.debug(f"{sa.__class__.__name__}({sa})")
                         assert sa.output_dir is not None
                         sa.output_dir.mkdir(parents=True, exist_ok=True)
                         (sa.output_dir / "sample_args.json").write_text(sa.model_dump_json())
                         self._run_text_guardrail(str(sa.output_dir), prompt)
         except Exception as e:
-            return [
-                self._handle_sample_exception(sa, e)
-                for sa in sample_args_list
-                if self.should_process_sample(sa) and not warmup
-            ]
+            return [self._handle_sample_exception(sa, e) for sa in sample_args_list if self.should_process_sample(sa)]
 
         # Collective call: every rank must enter so FSDP unshard/reshard and the
         # cross-rank early-exit reduction stay in lockstep. Not wrapped in try/except.
@@ -1922,7 +1927,7 @@ class OmniInference(Inference):
                 seed=sample_args_list[0].seed,
             )
 
-        if warmup:
+        if not save_outputs:
             return []
 
         sample_outputs: list[SampleOutputs] = []

--- a/cosmos_framework/inference/inference_test.py
+++ b/cosmos_framework/inference/inference_test.py
@@ -323,7 +323,7 @@ def test_generate_reasoner_batch_writes_outputs(tmp_path: Path) -> None:
     pipe._get_timer = lambda *_a, **_kw: nullcontext()  # type: ignore[attr-defined]
 
     data_batch = {"caption": ["Describe a robotic arm."], "reasoner_images": [None]}
-    results = pipe._generate_reasoner_batch([sample_args], data_batch, warmup=False)
+    results = pipe._generate_reasoner_batch([sample_args], data_batch)
 
     assert len(results) == 1
     so = results[0]
@@ -352,7 +352,7 @@ def test_generate_reasoner_batch_rejects_mixed_image_text_only(tmp_path: Path) -
         "reasoner_images": [PIL.new("RGB", (8, 8)), None],
     }
     with pytest.raises(ValueError, match="mixes image-conditioned and text-only"):
-        pipe._generate_reasoner_batch([sa1, sa2], data_batch, warmup=False)
+        pipe._generate_reasoner_batch([sa1, sa2], data_batch)
 
 
 @pytest.mark.L0

--- a/cosmos_framework/inference/inference_test.py
+++ b/cosmos_framework/inference/inference_test.py
@@ -10,6 +10,27 @@ from unittest.mock import Mock
 import pytest
 
 
+def test_finalize_data_batch_does_not_mutate_reusable_video_list() -> None:
+    torch = pytest.importorskip("torch")
+
+    from cosmos_framework.inference.inference import _finalize_data_batch
+
+    model = SimpleNamespace(input_video_key="video", input_image_key="images", input_caption_key="caption")
+    original_video = torch.zeros(3, 2, 4, 4, dtype=torch.uint8)
+    source_batch = {"video": [original_video], "caption": ["prompt"]}
+
+    first_pass = _finalize_data_batch(source_batch, batch_size=1, model=model)
+    first_pass["video"][0] = first_pass["video"][0].float() / 127.5 - 1.0
+    first_pass["is_preprocessed"] = True
+    second_pass = _finalize_data_batch(source_batch, batch_size=1, model=model)
+
+    assert first_pass["video"] is not source_batch["video"]
+    assert second_pass["video"] is not source_batch["video"]
+    assert source_batch["video"][0] is original_video
+    assert source_batch["video"][0].dtype == torch.uint8
+    assert "is_preprocessed" not in source_batch
+
+
 def _make_v2v_sample_args(**overrides: Any) -> SimpleNamespace:
     """v2v ``OmniSampleArgs`` stand-in for ``get_sample_data`` tests."""
     from cosmos_framework.inference.args import ModelMode, NegativeMetadataMode


### PR DESCRIPTION
#### Summary
Adds a new --num-iterations option to Cosmos3 inference for collecting multiple benchmark measurements in one invocation. Two additions that make benchmark timing clean and attributable

Finer-grained generate_batch sub-timers — prepare_inputs, resolve_upsample_tasks, save_outputs. These pinpoint where per-iteration time goes (and originally exposed the ~0.7s first-iteration overhead as output persistence, not compute).
Save the artifact during the last warmup pass — in benchmark mode with warmup >= 1, the final warmup pass runs the real save path (dir creation, guardrail lazy-load, first ffmpeg spawn, video write). Every measured iteration is then pure generate+decode, so iterations are uniform with no first-iteration skew. The artifact is still produced (from the deterministic, identical-seed warmup pass). --profile wraps only the (non-measured) save pass, so it never perturbs a measured iteration.
Behavior Defaults to one measured iteration. Values greater than one require --benchmark. Warmup runs remain separate from measured iterations. Each iteration executes the complete generation and decode workload. Only the first measured iteration writes output artifacts. Benchmark timing contains one entry per measured iteration. Copies mutable batch containers between runs to prevent one iteration from affecting another. Supports standard, transfer, and reasoner inference paths. Example

```
torchrun --nproc_per_node=1 \
  -m cosmos3.scripts.inference \
  -i inputs/omni/t2v.json \
  -o outputs/omni \
  --checkpoint-path Cosmos3-Edge \
  --warmup 1 \
  --benchmark \
  --num-iterations 4
```

#### Averaging policy (get_timer_results)
warmup >= 1: measured iterations are uniform → average is the plain mean.
warmup == 0: there is no warmup pass, so the first measured iteration is the cold pass (it saves the artifact + pays compile/setup) → it is dropped from average. Raw per-sample values are always kept in all.
#### Validation (RTX Pro 6000, Cosmos3-Edge, --warmup 1 --num-iterations 4 --benchmark)
Measured generate_batch: [51.5, 52.7, 53.1, 53.5]s — no first-iteration spike (first is fastest; remaining creep is thermal).
save_outputs for measured iterations: empty; save cost (1.7s) is recorded once under [warmup] save_outputs.
Artifact (vision.mp4) produced; exit 0.