### PR TITLE
Release 2026-07-27 (i4 a8a8218c)

### DIFF
--- a/.file_mapping.json
+++ b/.file_mapping.json
@@ -1,7 +1,7 @@
 {
-  "_source_commit": "a64e2735cce69f9fd388c3e19e4e04d22db7859b",
-  "_dest_commit": "2190a72a5799ab1bc8e4ddc19ae09cd1f14d7cbc",
-  "_generated_at": "2026-07-27T06:08:57Z",
+  "_source_commit": "a8a8218c95bc52340bfac0a31d18220ca54c8c63",
+  "_dest_commit": "09f23119ea92c707207bba55565e7a09d16896a2",
+  "_generated_at": "2026-07-27T13:48:45Z",
   "files": {
     "imaginaire/__init__.py": "cosmos_framework/__init__.py",
     "imaginaire/attention/__init__.py": "cosmos_framework/model/attention/__init__.py",

--- a/cosmos_framework/checkpoint/dcp.py
+++ b/cosmos_framework/checkpoint/dcp.py
@@ -71,9 +71,9 @@ from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_framework.checkpoint.base import AbstractCheckpointer
 from cosmos_framework.checkpoint.s3_filesystem import S3StorageReader, S3StorageWriter
+from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import callback, distributed, log, misc
-from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.utils.generator.rand_state import get_rand_state_dict, set_rand_state_dict
 

--- a/cosmos_framework/inference/common/distillation_export_test.py
+++ b/cosmos_framework/inference/common/distillation_export_test.py
@@ -12,6 +12,7 @@ from cosmos_framework.inference.common.distillation_export import (
 )
 
 
+
 def test_sanitize_student_model_config_removes_distillation_state() -> None:
     fixed_step_sampler_config = {
         "sample_type": "ode",

--- a/cosmos_framework/model/generator/mot/attention.py
+++ b/cosmos_framework/model/generator/mot/attention.py
@@ -95,6 +95,7 @@ def _is_split_info_compatible(attention_mask: object) -> bool:
 _dotproduct_attention_cache = {}
 
 
+from cosmos_framework.model.generator.mot.flex_attention import FlexMetadata, flex_attention_varlen
 from cosmos_framework.data.generator.sequence_packing.natten import (
     generate_natten_metadata,
     generate_temporal_causal_natten_metadata,
@@ -107,7 +108,6 @@ from cosmos_framework.data.generator.sequence_packing.runtime import (
     get_full_only_seq,
     sequence_pack_from_packed_sequence,
 )
-from cosmos_framework.model.generator.mot.flex_attention import FlexMetadata, flex_attention_varlen
 
 
 def two_way_attention(

--- a/cosmos_framework/model/generator/tokenizers/dc_ae/dc_ae_4x32x32.py
+++ b/cosmos_framework/model/generator/tokenizers/dc_ae/dc_ae_4x32x32.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 import torch
 
+from cosmos_framework.utils import log
+from cosmos_framework.utils.distributed import get_rank, sync_model_states
+from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.data.generator.utils import VIDEO_RES_SIZE_INFO
 from cosmos_framework.model.generator.tokenizers.dc_ae.dc_ae_v import (
     DCAEV,
@@ -13,9 +16,6 @@ from cosmos_framework.model.generator.tokenizers.dc_ae.dc_ae_v import (
     dc_ae_v_f32t4_encoder_causal_decoder_chunk_causal_4,
 )
 from cosmos_framework.model.generator.tokenizers.interface import VideoTokenizerInterface
-from cosmos_framework.utils import log
-from cosmos_framework.utils.distributed import get_rank, sync_model_states
-from cosmos_framework.utils.easy_io import easy_io
 
 DEFAULT_MODEL_NAME = "dcae4x32x32_c64_t120_256p_fps_all_encoder_causal_decoder_chunk_causal_4_nogan_cosmos_pad_7_v0.2"
 

--- a/cosmos_framework/utils/device.py
+++ b/cosmos_framework/utils/device.py
@@ -87,6 +87,7 @@ def gpu0_has_80gb_or_less():
 
 
 class Device:
+
     _nvml_affinity_elements = math.ceil(os.cpu_count() / 64)  # type: ignore
 
     def __init__(self, device_idx: int):

--- a/cosmos_framework/utils/distributed.py
+++ b/cosmos_framework/utils/distributed.py
@@ -19,8 +19,8 @@ import torch
 import torch.distributed as dist
 from torch.distributed import get_process_group_ranks
 
-from cosmos_framework.utils.device import Device
 from cosmos_framework.utils.flags import INTERNAL
+from cosmos_framework.utils.device import Device
 
 if dist.is_available():
     from torch.distributed.distributed_c10d import _get_default_group


### PR DESCRIPTION
Forward release from imaginaire4 to cosmos-framework: mapped file moves + import-path rewrites only, no code-level changes.

**6 files changed, 0 new.** Drift gate clean.

Note: the release pipeline now treats this repo's `.file_mapping.json` as the single source of truth for the mapping baseline (there is no i4-side copy), so the manifest here always matches what the drift gate checks against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)