### PR TITLE
fix(action): validate nano DROID policy SFT TOML against the schema (#138)

### DIFF
--- a/cosmos_framework/configs/base/experiment/action/posttrain_config/action_policy_droid_nano.py
+++ b/cosmos_framework/configs/base/experiment/action/posttrain_config/action_policy_droid_nano.py
@@ -172,12 +172,12 @@ action_policy_droid_nano = LazyDict(
             tokenizer_spatial_compression_factor=16,
             tokenizer_temporal_compression_factor=4,
             dataloader=L(RankPartitionedDataLoader)(
-                batch_size=1,
+                batch_size=16,
                 in_order=False,
-                num_workers=4,
+                num_workers=16,  # host-CPU-bound; lower via CLI on smaller hosts
                 persistent_workers=True,
                 pin_memory=True,
-                prefetch_factor=4,
+                prefetch_factor=2,
                 sampler=None,
                 # Shuffling is handled by the dataset (iterable_shuffle=True below):
                 # ActionIterableShuffleDataset streams rank x worker-sharded, episode-order-

--- a/cosmos_framework/configs/toml_config/sft_config_test.py
+++ b/cosmos_framework/configs/toml_config/sft_config_test.py
@@ -192,3 +192,39 @@ class TestEndToEndLoader:
         config = _load_or_skip(toml_path)
 
         assert config.custom == {}
+
+
+# --------------------------------------------------------------------------- #
+# 4. Every shipped example TOML validates + builds overrides                   #
+# --------------------------------------------------------------------------- #
+_EXAMPLE_TOML_DIR = Path(__file__).parents[3] / "examples" / "toml" / "sft_config"
+_EXAMPLE_TOMLS = sorted(_EXAMPLE_TOML_DIR.glob("*.toml"))
+
+
+class TestExampleTomlConfigs:
+    """Every TOML shipped under ``examples/toml/sft_config/`` must both validate
+    against ``SFTExperimentConfig`` (``extra="forbid"`` rejects any block the
+    schema does not register) and produce a Hydra override list. Catches, e.g., a
+    recipe TOML carrying a ``[model.*]`` / ``[dataloader_train.*]`` sub-block the
+    schema never modelled, which would raise ``ValidationError`` at load time.
+    """
+
+    def test_examples_dir_is_nonempty(self) -> None:
+        assert _EXAMPLE_TOMLS, f"no example TOMLs found under {_EXAMPLE_TOML_DIR}"
+
+    @pytest.mark.parametrize("toml_path", _EXAMPLE_TOMLS, ids=lambda p: p.name)
+    def test_example_toml_validates_and_builds_overrides(self, toml_path: Path) -> None:
+        import tomllib
+
+        raw = tomllib.loads(toml_path.read_text())
+
+        # 1. Schema validation — extra="forbid" flags un-registered TOML blocks.
+        try:
+            SFTExperimentConfig.model_validate(raw)
+        except ValidationError as exc:  # pragma: no cover - failure detail
+            pytest.fail(f"{toml_path.name} failed schema validation:\n{exc}")
+
+        # 2. Override construction — every leaf must route through PATH_REMAPS.
+        overrides = build_hydra_overrides(raw)
+        assert overrides[0] == "--"
+        assert any(o.startswith("experiment=") for o in overrides), overrides

--- a/examples/toml/sft_config/action_policy_droid_nano.toml
+++ b/examples/toml/sft_config/action_policy_droid_nano.toml
@@ -38,9 +38,6 @@ save_ops_regex = ["fmha"]
 [model.tokenizer]
 vae_path = "${oc.env:WAN_VAE_PATH}"
 
-[model.rectified_flow_training_config]
-loss_scale = 10.0    # generator (diffusion) loss weight, reference value
-
 [optimizer]
 lr = 2.0e-04
 
@@ -49,11 +46,6 @@ cycle_lengths = [100000]   # long cosine cycle: lr decays slowly across the 1000
 
 [dataloader_train]
 max_samples_per_batch = 32   # samples packed into each per-rank batch (res480)
-
-[dataloader_train.dataloader]
-num_workers     = 16   # decode-worker throughput tuning; adjust to host CPU count
-batch_size      = 16
-prefetch_factor = 2
 
 [trainer]
 max_iter        = 10000


### PR DESCRIPTION
## Summary

The `action_policy_droid_nano` post-training config could not be loaded via the documented `--sft-toml` entry point: `examples/toml/sft_config/action_policy_droid_nano.toml` carried `[model.rectified_flow_training_config]` and `[dataloader_train.dataloader]` blocks that `SFTExperimentConfig` (`extra="forbid"`) does not model, so `load_experiment_from_toml` raised `ValidationError`. Addresses #138.

## Fix (mirrors the edge recipe)

Keep these values in the registered recipe instead of the TOML:
- Set the inner dataloader scalars (`batch_size=16` / `num_workers=16` / `prefetch_factor=2`, the reference values) in `action_policy_droid_nano`.
- Drop both blocks from the TOML (`loss_scale=10` was already set in the recipe).

The TOML now contains only schema-registered blocks, so it validates with no schema change — consistent with how `action_policy_droid_edge` already works, and with i4 (which keeps `loss_scale`/dataloader in the experiment config).

## Test

`TestExampleTomlConfigs` in `sft_config_test.py` is parametrized over **every** `examples/toml/sft_config/*.toml`, validating each against `SFTExperimentConfig` and building its Hydra override list. The existing `unittest` job in `gpu-tests.yml` runs `pytest cosmos_framework/`, so the new test is picked up automatically (no new workflow needed).

Verified locally: all 12 example TOMLs pass validation + override construction with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
