### PR TITLE
fix(checkpoints): constrain tqdm for Hugging Face downloads

### DIFF
--- a/cosmos_framework/utils/checkpoint_db.py
+++ b/cosmos_framework/utils/checkpoint_db.py
@@ -150,6 +150,8 @@ def _hf_download(cmd_args: list[str]) -> str:
         "uvx",
         "--with",
         "click",
+        "--with",
+        "tqdm<4.70",
         f"hf@{HF_VERSION}",
         "download",
         "--format=json",


### PR DESCRIPTION
## Outcome

Restore Cosmos3 checkpoint downloads after tqdm 4.70 changed concurrent iterable length handling. The isolated Xet-capable `hf@1.16.4` tool now resolves with `tqdm<4.70`; the repository-bundled Hugging Face dependency remains unchanged.

Upstream context: https://github.com/tqdm/tqdm/releases/tag/v4.70.0

## Review path

Review the two added `uvx` requirement arguments in `cosmos_framework/utils/checkpoint_db.py`. Existing checkpoint download behavior is otherwise unchanged.

## Verification

- Verified `_hf_download` constructs `uvx --with click --with tqdm<4.70 hf@1.16.4 download ...` using a mocked subprocess.
- `uv run ruff format --check cosmos_framework/utils/checkpoint_db.py`
- `git diff --check`
- `ruff check` reports only the pre-existing import-order issue on `origin/main` in the same file.

## Risk and rollback

The constraint applies only to the transient Hugging Face CLI environment. Rollback is removal of the added `--with tqdm<4.70` requirement.