### PR TITLE
fix(checkpoints): repin Super 4Step checkpoints to main

### DIFF
--- a/cosmos_framework/inference/args.py
+++ b/cosmos_framework/inference/args.py
@@ -1223,7 +1223,7 @@ _CHECKPOINTS: dict[str, CheckpointConfig] = {
         s3_uri="s3://bucket1/cosmos3_vfm/cosmos3_ga_text2image_4step/",
         hf=CheckpointDirHf(
             repository="nvidia/Cosmos3-Super-Text2Image-4Step",
-            revision="1ba94110bc118f479bbd5e461e79d685d74b2554",
+            revision="main",
         ),
         experiment_overrides=(
             "model.config.resolution='768'",
@@ -1245,7 +1245,7 @@ _CHECKPOINTS: dict[str, CheckpointConfig] = {
         s3_uri="s3://bucket1/cosmos3_vfm/cosmos3_ga_image2video_4step/",
         hf=CheckpointDirHf(
             repository="nvidia/Cosmos3-Super-Image2Video-4Step",
-            revision="f85d3335d2ad8b352462cecbd637aa980cec9688",
+            revision="main",
         ),
         experiment_overrides=(
             "model.config.resolution='480'",

--- a/cosmos_framework/inference/args_test.py
+++ b/cosmos_framework/inference/args_test.py
@@ -151,14 +151,14 @@ def test_checkpoints():
         (
             "Cosmos3-Super-Text2Image-4Step",
             "nvidia/Cosmos3-Super-Text2Image-4Step",
-            "1ba94110bc118f479bbd5e461e79d685d74b2554",
+            "main",
             "768",
             24,
         ),
         (
             "Cosmos3-Super-Image2Video-4Step",
             "nvidia/Cosmos3-Super-Image2Video-4Step",
-            "f85d3335d2ad8b352462cecbd637aa980cec9688",
+            "main",
             "480",
             16,
         ),


### PR DESCRIPTION
## Problem

`distilled-inference-smoke` fails during checkpoint download, before inference ever starts:

```
403 Forbidden
Cannot access content at: https://cdn-lfs-us-1.hf.co/repos/01/58/.../be75606093db...
<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>
subprocess.CalledProcessError: ['uvx', ..., 'hf@1.16.4', 'download',
  'nvidia/Cosmos3-Super-Text2Image-4Step', '--revision', '1ba94110bc...']
```

rank 0 fails → ranks 1-3 raise `RuntimeError: Rank 0 download failed` → `ChildFailedError`.

Seen on #134 ([job](https://github.com/NVIDIA/cosmos-framework/actions/runs/30432072419/job/90521649702)), where both the T2I and I2V cases died this way — nothing to do with that PR's changes.

## Root cause

The LFS blobs behind the two pinned commits are still served from the legacy `cdn-lfs-us-1.hf.co` bucket, and those objects were reclaimed after the repos migrated to Xet. The same files on each repo's `main` branch serve fine from `us.aws.cdn.hf.co`.

Reproduced deterministically with plain `curl` (3/3 attempts):

| repo | file | pinned rev | `main` |
|---|---|---|---|
| `Cosmos3-Super-Text2Image-4Step` | `text_tokenizer/tokenizer.json` | **403** | 200 |
| `Cosmos3-Super-Image2Video-4Step` | `transformer/diffusion_pytorch_model-00001-of-00027.safetensors` | **403** | 206 |

`tokenizer.json` has a different oid and size across the two revisions (`be7560…`/11422650 vs `aeb133…`/11422654), i.e. the file was rewritten after we pinned and the old blob is gone.

`main` CI stays green only because its runner (`computeinstance-e01yhncr…`) has these files cached — the download command returns in 1.2 s without touching the CDN. #134 landed on `computeinstance-e01kqprb…` with a cold cache and hit the real fetch. **Any PR scheduled onto a cold-cache runner fails the same way.**

## Fix

Repin both to `revision="main"`, matching the other five Cosmos3 checkpoints in the same registry.

## Scope check

Swept every 40-hex `revision=` pin in the repo against the Hub with an `HF_TOKEN` (first 8 LFS files per repo, ranged GET). Only these two are affected:

| repo @ pinned rev | result |
|---|---|
| `Cosmos3-Super-Text2Image-4Step` @ `1ba94110` | **403** |
| `Cosmos3-Super-Image2Video-4Step` @ `f85d3335` | **403** |
| `Cosmos3-Nano-Reasoner` @ `6406357c` | OK |
| `Cosmos3-Super-Reasoner` @ `b9b716f3` | OK |
| `Cosmos3-Experimental` @ `6ca42c5d` / `a3743aa1` | OK |
| `Cosmos-Guardrail1` @ `d6d4bfa8` | OK |
| `Wan2.1-T2V-14B`, `Wan2.2-TI2V-5B` | OK |
| `BridgeData2-Subset-Synthetic-Captions`, `LIBERO_LeRobot_v3`, `bridge_lerobot_v3` | OK |

`Cosmos3-Edge` already uses `revision="main"` in both `inference/common/checkpoints.py` and `configs/base/experiment/sft/models/edge_model_config.py`.

## Verification

```
$ pytest cosmos_framework/inference/args_test.py -k distilled_checkpoint_uses_published
2 passed

$ pytest cosmos_framework/inference/args_test.py -k test_checkpoints
1 passed
```

`test_checkpoints` really downloads `config.json` / `transformer/config.json` for every registered checkpoint, so it confirms both `main` revisions resolve and fetch.

## Follow-up (not in this PR)

The comment at `args_test.py:129-131` says the 4-step repos are gated, but the Hub now reports `gated: false, private: false` for both and they fetch anonymously. The `HF_TOKEN` skip branch in `test_checkpoints` looks droppable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
