### PR TITLE
feat: add TAO WTS and AETC SFT support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .venv
 .git
+**/__pycache__
+**/*.pyc
 /checkpoints
 /datasets
 /output

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=.python-version,target=.python-version \
     --mount=type=bind,source=packages,target=packages \
-    uv sync --locked --no-install-project --no-editable --all-extras --group=$(cat /root/.cuda-name) --group=vllm
+    uv sync --locked --no-install-project --no-editable --all-extras --group=$(cat /root/.cuda-name)-train
 ENV PATH="/workspace/.venv/bin:$PATH"
+
+# Package the exact source state into the image so it can run on managed
+# platforms without a host bind mount.
+COPY . /workspace
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --no-deps .
 
 # Triton bundled ptxas doesn't support latest GPU architectures
 ENV TRITON_PTXAS_PATH="/usr/local/cuda/bin/ptxas"

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ WORKDIR /workspace
 # Install python
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=.python-version,target=.python-version \
-    uv python install
+    uv python install && \
+    chmod 0711 /root
 
 # Install into virtual environment
 RUN echo "$CUDA_VERSION" | sed -E 's/^([0-9]+)\.([0-9]+).*/cu\1\2/' > /root/.cuda-name

--- a/cosmos_framework/callbacks/tao_status.py
+++ b/cosmos_framework/callbacks/tao_status.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""TAO-compatible lifecycle and metric logging for Cosmos Framework training."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from cosmos_framework.utils import distributed, log, misc
+from cosmos_framework.utils.callback import Callback
+
+
+def _to_json_value(value: Any) -> Any:
+    """Recursively convert tensors and array-like values to JSON-safe values."""
+    if isinstance(value, dict):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_json_value(item) for item in value]
+    if isinstance(value, torch.Tensor):
+        value = value.detach()
+        if value.numel() == 1:
+            return value.item()
+        return value.cpu().tolist()
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    if hasattr(value, "tolist"):
+        try:
+            return value.tolist()
+        except (TypeError, ValueError):
+            pass
+    return value
+
+
+class _TAOStatusWriter:
+    """Use TAO Core when available, with a compatible JSON-lines fallback."""
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        Path(filename).parent.mkdir(parents=True, exist_ok=True)
+        self._tao_logger = None
+        self._tao_status = None
+        self._tao_verbosity = None
+
+        try:
+            from nvidia_tao_core.loggers.logging import Status, StatusLogger, Verbosity
+        except ImportError:
+            log.warning(f"nvidia_tao_core is not installed; writing TAO-compatible JSON records directly to {filename}")
+        else:
+            self._tao_status = Status
+            self._tao_verbosity = Verbosity
+            self._tao_logger = StatusLogger(
+                filename=filename,
+                is_master=True,
+                verbosity=Verbosity.INFO,
+                append=True,
+            )
+
+    def write(
+        self,
+        *,
+        status: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+        kpi: dict[str, Any] | None = None,
+        verbosity: str = "INFO",
+    ) -> None:
+        data = _to_json_value(data or {})
+        kpi = _to_json_value(kpi or {})
+
+        if self._tao_logger is not None:
+            status_level = getattr(self._tao_status, status)
+            verbosity_level = getattr(self._tao_verbosity, verbosity)
+            self._tao_logger.kpi = kpi
+            self._tao_logger.write(
+                data=data,
+                status_level=status_level,
+                verbosity_level=verbosity_level,
+                message=message,
+            )
+            return
+
+        now = datetime.now()
+        payload: dict[str, Any] = {
+            **data,
+            "date": f"{now.month}/{now.day}/{now.year}",
+            "time": f"{now.hour}:{now.minute}:{now.second}",
+            "status": status,
+            "verbosity": verbosity,
+            "message": message,
+        }
+        if kpi:
+            payload["kpi"] = kpi
+        with open(self.filename, "a", encoding="utf-8") as status_file:
+            status_file.write(json.dumps(payload, default=str) + "\n")
+
+
+class TAOStatusCallback(Callback):
+    """Write TAO lifecycle, training, and validation records from rank zero.
+
+    The output path is resolved in this order:
+
+    1. ``status_file_path`` when explicitly configured.
+    2. ``$TAO_RESULTS_ROOT/$TAO_JOB_ID/status.json`` (TAO SDK).
+    3. ``$TAO_API_RESULTS_DIR/$TAO_API_JOB_ID/status.json`` (TAO API).
+    4. ``<job.path_local>/status.json`` for direct launches.
+    """
+
+    def __init__(
+        self,
+        enabled: bool = False,
+        status_file_path: str | None = None,
+        experiment_name: str = "",
+        logging_interval: int = 1,
+        validation_heartbeat_interval: int = 1,
+    ) -> None:
+        if logging_interval < 1:
+            raise ValueError("logging_interval must be >= 1")
+        if validation_heartbeat_interval < 1:
+            raise ValueError("validation_heartbeat_interval must be >= 1")
+        self.enabled = enabled
+        self.status_file_path = status_file_path
+        self.experiment_name = experiment_name
+        self.logging_interval = logging_interval
+        self.validation_heartbeat_interval = validation_heartbeat_interval
+        self._writer: _TAOStatusWriter | None = None
+        self._train_start_time = 0.0
+        self._step_start_time = 0.0
+        self._validation_batches = 0
+        self._validation_loss_sum = 0.0
+        self._validation_sample_count = 0
+        self.last_validation_loss: float | None = None
+
+    def _is_rank_zero(self) -> bool:
+        if dist.is_available() and dist.is_initialized():
+            return distributed.is_rank0()
+        return int(os.environ.get("RANK", os.environ.get("LOCAL_RANK", "0"))) == 0
+
+    def _component_name(self) -> str:
+        if self.experiment_name:
+            return self.experiment_name
+        return getattr(self.config.job, "name", "Cosmos Framework SFT")
+
+    def _resolve_status_file(self) -> str:
+        if self.status_file_path:
+            return self.status_file_path
+
+        job_id = os.environ.get("TAO_JOB_ID")
+        if job_id:
+            results_root = os.environ.get("TAO_RESULTS_ROOT", "/results")
+            return os.path.join(results_root, job_id, "status.json")
+
+        api_job_id = os.environ.get("TAO_API_JOB_ID")
+        if api_job_id:
+            results_root = os.environ.get("TAO_API_RESULTS_DIR", "/results")
+            return os.path.join(results_root, api_job_id, "status.json")
+
+        return os.path.join(self.config.job.path_local, "status.json")
+
+    def _get_writer(self) -> _TAOStatusWriter | None:
+        if not self.enabled or not self._is_rank_zero():
+            return None
+        if self._writer is None:
+            self._writer = _TAOStatusWriter(self._resolve_status_file())
+        return self._writer
+
+    def _progress_data(self, iteration: int, seconds_per_step: float | None = None) -> dict[str, Any]:
+        trainer = getattr(self, "trainer", None)
+        max_step = int(getattr(trainer, "max_iterations", self.config.trainer.max_iter))
+        if seconds_per_step is None:
+            elapsed = max(time.monotonic() - self._train_start_time, 0.0)
+            seconds_per_step = elapsed / max(iteration, 1)
+        eta_seconds = max(max_step - iteration, 0) * seconds_per_step
+        data = {
+            "component": self._component_name(),
+            "step": iteration,
+            "max_step": max_step,
+            "time_per_step": str(timedelta(seconds=seconds_per_step)),
+            "eta": str(timedelta(seconds=eta_seconds)),
+        }
+        steps_per_epoch = getattr(trainer, "steps_per_epoch", None)
+        num_epochs = getattr(trainer, "num_epochs", None)
+        if steps_per_epoch and num_epochs:
+            completed_epochs = iteration // steps_per_epoch
+            if iteration == 0:
+                epoch = 1
+                step_in_epoch = 0
+            elif iteration % steps_per_epoch == 0:
+                epoch = min(completed_epochs, num_epochs)
+                step_in_epoch = steps_per_epoch
+            else:
+                epoch = min(completed_epochs + 1, num_epochs)
+                step_in_epoch = iteration % steps_per_epoch
+            data.update(
+                {
+                    "epoch": epoch,
+                    "max_epoch": num_epochs,
+                    "completed_epochs": min(completed_epochs, num_epochs),
+                    "step_in_epoch": step_in_epoch,
+                    "steps_per_epoch": steps_per_epoch,
+                    "time_per_epoch": str(timedelta(seconds=seconds_per_step * steps_per_epoch)),
+                }
+            )
+        return data
+
+    def _epoch_label(self, iteration: int) -> str:
+        progress = self._progress_data(iteration, seconds_per_step=0.0)
+        if "epoch" not in progress:
+            return f"training step {iteration}/{progress['max_step']}"
+        return f"epoch {progress['epoch']}/{progress['max_epoch']}"
+
+    @staticmethod
+    def _global_average_loss(loss: torch.Tensor, data_batch: dict[str, Any]) -> tuple[float, int]:
+        sample_count = misc.get_data_batch_size(data_batch)
+        loss_sum = loss.detach() * sample_count
+        count = torch.tensor(sample_count, device=loss.device, dtype=torch.long)
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(count, op=dist.ReduceOp.SUM)
+        global_count = int(count.item())
+        average = float(loss_sum.item()) / max(global_count, 1)
+        return average, global_count
+
+    def on_train_start(self, model: Any, iteration: int = 0) -> None:
+        self._train_start_time = time.monotonic()
+        writer = self._get_writer()
+        if writer is not None:
+            writer.write(
+                status="STARTED",
+                message=f"Starting {self._component_name()} training",
+                data=self._progress_data(iteration, seconds_per_step=0.0),
+            )
+            log.info(f"TAO status will be logged to {writer.filename}")
+
+    def on_training_step_start(self, model: Any, data: dict[str, Any], iteration: int = 0) -> None:
+        self._step_start_time = time.monotonic()
+
+    def on_training_step_end(
+        self,
+        model: Any,
+        data_batch: dict[str, Any],
+        output_batch: dict[str, Any],
+        loss: torch.Tensor,
+        iteration: int = 0,
+    ) -> None:
+        interval = int(self.config.trainer.logging_iter) * self.logging_interval
+        if iteration % interval != 0:
+            return
+
+        average_loss, _ = self._global_average_loss(loss, data_batch)
+        writer = self._get_writer()
+        if writer is None:
+            return
+        seconds_per_step = max(time.monotonic() - self._step_start_time, 0.0)
+        kpi = {"train/loss": average_loss, "train/loss_avg": average_loss}
+        progress = self._progress_data(iteration, seconds_per_step=seconds_per_step)
+        if "epoch" in progress:
+            message = (
+                f"Training epoch {progress['epoch']}/{progress['max_epoch']}, "
+                f"step {progress['step_in_epoch']}/{progress['steps_per_epoch']} "
+                f"(global step {iteration}/{progress['max_step']}) - Loss: {average_loss:.6f}"
+            )
+        else:
+            message = f"Training step {iteration}/{progress['max_step']} - Loss: {average_loss:.6f}"
+        writer.write(
+            status="RUNNING",
+            message=message,
+            data=progress,
+            kpi=kpi,
+        )
+
+    def on_validation_start(self, model: Any, dataloader_val: Any, iteration: int = 0) -> None:
+        self._validation_batches = 0
+        self._validation_loss_sum = 0.0
+        self._validation_sample_count = 0
+        writer = self._get_writer()
+        if writer is not None:
+            writer.write(
+                status="RUNNING",
+                message=f"Starting validation for {self._epoch_label(iteration)}",
+                data={**self._progress_data(iteration), "phase": "validation_starting"},
+            )
+            log.info(f"Starting validation for {self._epoch_label(iteration)}")
+
+    def on_validation_step_end(
+        self,
+        model: Any,
+        data_batch: dict[str, Any],
+        output_batch: dict[str, Any],
+        loss: torch.Tensor,
+        iteration: int = 0,
+    ) -> None:
+        average_loss, sample_count = self._global_average_loss(loss, data_batch)
+        self._validation_batches += 1
+        self._validation_loss_sum += average_loss * sample_count
+        self._validation_sample_count += sample_count
+
+        if self._validation_batches % self.validation_heartbeat_interval != 0:
+            return
+        writer = self._get_writer()
+        max_validation_batches = getattr(self.config.trainer, "max_val_iter", None)
+        batch_progress = (
+            f"{self._validation_batches}/{max_validation_batches}"
+            if max_validation_batches is not None
+            else str(self._validation_batches)
+        )
+        if writer is not None:
+            writer.write(
+                status="RUNNING",
+                message=(
+                    f"Validation {self._epoch_label(iteration)}, batch {batch_progress} - Loss: {average_loss:.6f}"
+                ),
+                data={
+                    **self._progress_data(iteration),
+                    "phase": "validation_batch_complete",
+                    "validation_batch": self._validation_batches,
+                    "max_validation_batches": max_validation_batches,
+                },
+                kpi={"val/batch_loss": average_loss},
+            )
+            log.info(f"Validation {self._epoch_label(iteration)}, batch {batch_progress} - Loss: {average_loss:.6f}")
+
+    def on_validation_end(self, model: Any, iteration: int = 0) -> None:
+        if self._validation_sample_count == 0:
+            log.warning("TAO validation logging saw zero samples; no val/loss record was written")
+            return
+
+        self.last_validation_loss = self._validation_loss_sum / self._validation_sample_count
+        writer = self._get_writer()
+        if writer is not None:
+            writer.write(
+                status="RUNNING",
+                message=(
+                    f"Validation complete for {self._epoch_label(iteration)} - Loss: {self.last_validation_loss:.6f}"
+                ),
+                data={
+                    **self._progress_data(iteration),
+                    "phase": "validation_complete",
+                    "validation_batches": self._validation_batches,
+                    "validation_samples": self._validation_sample_count,
+                },
+                kpi={"val/loss": self.last_validation_loss, "val/avg_loss": self.last_validation_loss},
+            )
+        log.info(f"Validation loss ({self._epoch_label(iteration)}): {self.last_validation_loss:.6f}")
+
+    def on_app_end(self) -> None:
+        writer = self._get_writer()
+        if writer is not None:
+            writer.write(
+                status="SUCCESS",
+                message=f"{self._component_name()} training completed successfully",
+                data=self._progress_data(
+                    int(getattr(getattr(self, "trainer", None), "max_iterations", self.config.trainer.max_iter))
+                ),
+                kpi=(
+                    {"val/loss": self.last_validation_loss, "val/avg_loss": self.last_validation_loss}
+                    if self.last_validation_loss is not None
+                    else None
+                ),
+            )
+
+    def on_exception(self, error: BaseException) -> None:
+        writer = self._get_writer()
+        if writer is not None:
+            writer.write(
+                status="FAILURE",
+                verbosity="ERROR",
+                message=f"{self._component_name()} training failed: {error}",
+                data={"component": self._component_name(), "error_type": type(error).__name__},
+            )

--- a/cosmos_framework/callbacks/tao_status_test.py
+++ b/cosmos_framework/callbacks/tao_status_test.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import torch
+
+from cosmos_framework.callbacks.tao_status import TAOStatusCallback
+
+
+def _callback(tmp_path) -> TAOStatusCallback:
+    callback = TAOStatusCallback(
+        enabled=True,
+        status_file_path=str(tmp_path / "status.json"),
+        experiment_name="test",
+    )
+    callback.config = SimpleNamespace(
+        job=SimpleNamespace(name="job", path_local=str(tmp_path)),
+        trainer=SimpleNamespace(max_iter=6, max_val_iter=2, logging_iter=1),
+    )
+    callback.trainer = SimpleNamespace(max_iterations=6, num_epochs=2, steps_per_epoch=3)
+    return callback
+
+
+def _records(tmp_path) -> list[dict]:
+    return [json.loads(line) for line in (tmp_path / "status.json").read_text(encoding="utf-8").splitlines()]
+
+
+def test_tao_status_callback_writes_training_validation_and_success(tmp_path) -> None:
+    callback = _callback(tmp_path)
+    callback.on_train_start(model=None, iteration=0)
+    callback.on_training_step_start(model=None, data={}, iteration=0)
+    callback.on_training_step_end(
+        model=None,
+        data_batch={"input_ids": torch.zeros(2, 3)},
+        output_batch={},
+        loss=torch.tensor(0.5),
+        iteration=3,
+    )
+    callback.on_validation_start(model=None, dataloader_val=None, iteration=3)
+    callback.on_validation_step_end(
+        model=None,
+        data_batch={"input_ids": torch.zeros(2, 3)},
+        output_batch={},
+        loss=torch.tensor(0.25),
+        iteration=3,
+    )
+    callback.on_validation_end(model=None, iteration=3)
+    callback.on_app_end()
+
+    records = _records(tmp_path)
+    assert [record["status"] for record in records] == [
+        "STARTED",
+        "RUNNING",
+        "RUNNING",
+        "RUNNING",
+        "RUNNING",
+        "SUCCESS",
+    ]
+    assert records[1]["kpi"]["train/loss_avg"] == 0.5
+    assert records[1]["epoch"] == 1
+    assert records[1]["max_epoch"] == 2
+    assert records[1]["step_in_epoch"] == 3
+    assert records[1]["steps_per_epoch"] == 3
+    assert records[1]["max_step"] == 6
+    assert records[2]["phase"] == "validation_starting"
+    assert records[3]["max_validation_batches"] == 2
+    assert "epoch 1/2" in records[3]["message"]
+    assert records[4]["kpi"]["val/avg_loss"] == 0.25
+    assert "epoch 1/2" in records[4]["message"]
+    assert records[-1]["kpi"]["val/loss"] == 0.25
+    assert records[-1]["epoch"] == 2
+    assert records[-1]["completed_epochs"] == 2
+
+
+def test_tao_status_callback_writes_failure(tmp_path) -> None:
+    callback = _callback(tmp_path)
+    callback.on_train_start(model=None, iteration=0)
+    callback.on_exception(RuntimeError("boom"))
+
+    records = _records(tmp_path)
+    assert records[-1]["status"] == "FAILURE"
+    assert records[-1]["error_type"] == "RuntimeError"

--- a/cosmos_framework/checkpoint/base.py
+++ b/cosmos_framework/checkpoint/base.py
@@ -7,11 +7,11 @@ from typing import Optional
 
 import torch
 
-from cosmos_framework.utils.config import CheckpointConfig, JobConfig
-from cosmos_framework.utils.flags import INTERNAL
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import callback
+from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.utils.easy_io import easy_io
+from cosmos_framework.utils.flags import INTERNAL
 
 
 class AbstractCheckpointer(ABC):
@@ -92,6 +92,7 @@ class AbstractCheckpointer(ABC):
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         pass
 

--- a/cosmos_framework/checkpoint/dcp.py
+++ b/cosmos_framework/checkpoint/dcp.py
@@ -71,9 +71,9 @@ from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_framework.checkpoint.base import AbstractCheckpointer
 from cosmos_framework.checkpoint.s3_filesystem import S3StorageReader, S3StorageWriter
-from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import callback, distributed, log, misc
+from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.utils.generator.rand_state import get_rand_state_dict, set_rand_state_dict
 
@@ -748,7 +748,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
 
                     # If the path doesn't end with specific checkpoint, read the latest
                     # checkpoint file to determine the most recent checkpoint iteration.
-                    if not re.search(r"/checkpoints/iter_\d{9}/?$", checkpoint_path):
+                    if not re.search(r"/checkpoints/(?:iter_\d{9}|epoch_\d+)/?$", checkpoint_path):
                         old_ckpt_path = checkpoint_path
                         latest_ckpt_path = os.path.join(checkpoint_path, "checkpoints/latest_checkpoint.txt")
 
@@ -1090,6 +1090,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         """Save network weights, optimizer parameters, scheduler parameters to a checkpoint.
 
@@ -1106,7 +1107,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
         if self.callbacks is not None:
             self.callbacks.on_save_checkpoint_start(model, iteration)
 
-        checkpoint_file = f"iter_{iteration:09}"
+        checkpoint_file = f"epoch_{epoch}" if epoch is not None else f"iter_{iteration:09}"
 
         # Use rank-specific key for RNG state to ensure each rank saves its own state
         rng_key = f"rng_state_{dist.get_rank()}"
@@ -1129,7 +1130,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
             self.callbacks.on_save_checkpoint(model, state_dict=to_save_dict)
 
         for k in to_save_dict.keys():
-            output_dirname = os.path.join(self.save_dirname, f"iter_{iteration:09}/{k}")
+            output_dirname = os.path.join(self.save_dirname, checkpoint_file, k)
             to_save_dict[k] = (to_save_dict[k], output_dirname)
 
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:

--- a/cosmos_framework/checkpoint/dcp_distill.py
+++ b/cosmos_framework/checkpoint/dcp_distill.py
@@ -26,9 +26,6 @@ from torch.distributed.checkpoint.state_dict import (
 from torch.distributed.checkpoint.stateful import Stateful
 from torch.nn.modules.module import _IncompatibleKeys
 
-from cosmos_framework.model._base import ImaginaireModel
-from cosmos_framework.utils import log, misc
-from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.checkpoint.dcp import (
     AsyncMode,
     CustomLoadPlanner,
@@ -38,8 +35,11 @@ from cosmos_framework.checkpoint.dcp import (
     DistributedCheckpointer as _DistributedCheckpointer,
 )
 from cosmos_framework.checkpoint.dcp import ModelWrapper as VFMModelWrapper
-from cosmos_framework.utils.generator.rand_state import get_rand_state_dict, set_rand_state_dict
+from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.model.generator.distillation.optimizer import OptimizerContainerLike, is_optimizer_container
+from cosmos_framework.utils import log, misc
+from cosmos_framework.utils.easy_io import easy_io
+from cosmos_framework.utils.generator.rand_state import get_rand_state_dict, set_rand_state_dict
 
 __all__: tuple[str, ...] = (
     "DistributedCheckpointer",
@@ -324,6 +324,7 @@ class DistributedCheckpointer(_DistributedCheckpointer):
         scheduler: Any = None,
         grad_scaler: torch.amp.GradScaler | None = None,
         iteration: int = 0,
+        epoch: int | None = None,
     ) -> None:
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:
             self._wait_for_previous_async_checkpoint()
@@ -332,7 +333,7 @@ class DistributedCheckpointer(_DistributedCheckpointer):
             self.callbacks.on_save_checkpoint_start(model, iteration)
 
         model_dict = model.model_dict()
-        checkpoint_file = f"iter_{iteration:09}"
+        checkpoint_file = f"epoch_{epoch}" if epoch is not None else f"iter_{iteration:09}"
 
         rng_key = f"rng_state_{dist.get_rank()}"
         to_save_dict: dict[str, Any] = {
@@ -360,7 +361,7 @@ class DistributedCheckpointer(_DistributedCheckpointer):
             to_save_dict["dataloader"] = dataloader_wrapper.state_dict()
 
         for key in list(to_save_dict.keys()):
-            output_dirname = os.path.join(self.save_dirname, f"iter_{iteration:09}/{key}")
+            output_dirname = os.path.join(self.save_dirname, checkpoint_file, key)
             to_save_dict[key] = (to_save_dict[key], output_dirname)
 
         if self.callbacks is not None:

--- a/cosmos_framework/checkpoint/dummy.py
+++ b/cosmos_framework/checkpoint/dummy.py
@@ -22,6 +22,7 @@ class Checkpointer(AbstractCheckpointer):
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         pass
 

--- a/cosmos_framework/configs/base/reasoner/defaults/callbacks.py
+++ b/cosmos_framework/configs/base/reasoner/defaults/callbacks.py
@@ -7,22 +7,22 @@ Based on projects/cosmos/ar/v1/configs/registry.py
 
 from hydra.core.config_store import ConfigStore
 
-from cosmos_framework.callbacks.manual_gc import ManualGarbageCollection
-from cosmos_framework.utils.lazy_config import PLACEHOLDER
-from cosmos_framework.utils.lazy_config import LazyCall as L
-from cosmos_framework.utils.callback import LowPrecisionCallback, WandBCallback
 from cosmos_framework.callbacks.dataloader_state import DataLoaderStateCallback
-
 from cosmos_framework.callbacks.grad_clip import GradClip
 from cosmos_framework.callbacks.hf_export import HFExportCallback
 from cosmos_framework.callbacks.iter_speed import IterSpeed
 from cosmos_framework.callbacks.learning_rate_logger import LearningRateLogger
 from cosmos_framework.callbacks.log_tensor_shape import LogTensorShapeCallback
+from cosmos_framework.callbacks.manual_gc import ManualGarbageCollection
 from cosmos_framework.callbacks.param_count import ParamCount
+from cosmos_framework.callbacks.tao_status import TAOStatusCallback
 from cosmos_framework.callbacks.tokens_per_sec import VLMTokensPerSec
 from cosmos_framework.callbacks.wandb_log import WandbCallback as WandBCallbackMultiplier
 from cosmos_framework.callbacks.wandb_vis import VisualizationLoggingCallback
 from cosmos_framework.configs.base.defaults.callbacks import JOB_MONITOR_CALLBACKS
+from cosmos_framework.utils.callback import LowPrecisionCallback, WandBCallback
+from cosmos_framework.utils.lazy_config import PLACEHOLDER
+from cosmos_framework.utils.lazy_config import LazyCall as L
 
 # from cosmos_framework.utils.callback import NVTXCallback
 
@@ -52,6 +52,13 @@ def register_callbacks():
             config=PLACEHOLDER,
             trainer=PLACEHOLDER,
         ),  # reads model.precision; no extra kwarg needed
+        tao=L(TAOStatusCallback)(
+            enabled=False,
+            status_file_path=None,
+            experiment_name="",
+            logging_interval=1,
+            validation_heartbeat_interval=1,
+        ),
         # nvtx=L(NVTXCallback)(synchronize=True),
     )
 

--- a/cosmos_framework/configs/base/reasoner/experiment/wts_vlm.py
+++ b/cosmos_framework/configs/base/reasoner/experiment/wts_vlm.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""Woven Traffic Safety (WTS) video-QA SFT on the Cosmos3-Nano VLM path."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import OrderedDict
+from copy import deepcopy
+from typing import Any
+
+import torch
+from hydra.core.config_store import ConfigStore
+from PIL import Image
+from torch.utils.data import Dataset
+
+from cosmos_framework.callbacks.cosmos_dataloader_state import CosmosDataLoaderStateCallback
+from cosmos_framework.configs.base.reasoner.experiment.dataflow_roles import VLMCollator, VLMProcessor
+from cosmos_framework.data.generator.dataflow import CosmosDataLoader, MapDistributor, PoolPackingBatcher
+from cosmos_framework.data.generator.processors import build_processor
+from cosmos_framework.utils.generator.torchcodec_video import TorchCodecVideoReader
+from cosmos_framework.utils.lazy_config import LazyCall as L
+from cosmos_framework.utils.lazy_config import LazyDict
+from cosmos_framework.utils.reasoner.constant import IGNORE_INDEX
+
+
+class WTSLlavaDataset(Dataset):
+    """Map-style loader for WTS LLaVA JSON annotations."""
+
+    def __init__(
+        self,
+        annotation_path: str,
+        media_path: str,
+        limit: int | str | None = None,
+    ) -> None:
+        self.annotation_path = os.path.abspath(os.path.expanduser(annotation_path))
+        self.media_path = os.path.abspath(os.path.expanduser(media_path))
+        if limit in ("", None):
+            parsed_limit = None
+        else:
+            parsed_limit = int(limit)
+            if parsed_limit < 1:
+                parsed_limit = None
+
+        with open(self.annotation_path, encoding="utf-8") as annotation_file:
+            records = json.load(annotation_file)
+        if not isinstance(records, list):
+            raise TypeError(f"WTS annotations must be a JSON array, got {type(records).__name__}")
+        self.records = records[:parsed_limit] if parsed_limit is not None else records
+        if not self.records:
+            raise ValueError(f"WTS annotation file contains no usable records: {self.annotation_path}")
+
+        for index, record in enumerate(self.records):
+            if not isinstance(record, dict) or not isinstance(record.get("video"), str):
+                raise ValueError(f"WTS record {index} must contain a string 'video' field")
+            conversations = record.get("conversations")
+            if not isinstance(conversations, list) or len(conversations) < 2:
+                raise ValueError(f"WTS record {index} must contain at least two conversation turns")
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        record = dict(self.records[index])
+        video_path = record["video"]
+        if not os.path.isabs(video_path):
+            video_path = os.path.join(self.media_path, video_path)
+        if not os.path.isfile(video_path):
+            raise FileNotFoundError(f"WTS video does not exist: {video_path}")
+        record["video"] = video_path
+        return record
+
+
+class WTSProcessor(VLMProcessor):
+    """Convert WTS ShareGPT records and uniformly sample each video to PIL frames."""
+
+    def __init__(
+        self,
+        processor: Any,
+        ignore_index: int = IGNORE_INDEX,
+        num_video_frames: int = 8,
+        video_cache_size: int = 8,
+        system_prompt: str = "",
+    ) -> None:
+        super().__init__(processor=processor, ignore_index=ignore_index)
+        if num_video_frames < 1:
+            raise ValueError("num_video_frames must be >= 1")
+        if video_cache_size < 0:
+            raise ValueError("video_cache_size must be >= 0")
+        self.num_video_frames = num_video_frames
+        self.video_cache_size = video_cache_size
+        self.system_prompt = system_prompt
+        self._video_cache: OrderedDict[str, tuple[list[Image.Image], float]] = OrderedDict()
+
+    def _decode_video(self, video_path: str) -> tuple[list[Image.Image], float]:
+        cached = self._video_cache.get(video_path)
+        if cached is not None:
+            self._video_cache.move_to_end(video_path)
+            return cached
+
+        reader = TorchCodecVideoReader(video_path, num_threads=2)
+        total_frames = len(reader)
+        if total_frames < 1:
+            raise ValueError(f"WTS video has zero frames: {video_path}")
+        sample_count = min(self.num_video_frames, total_frames)
+        if sample_count == 1:
+            indices = [0]
+        else:
+            indices = torch.linspace(0, total_frames - 1, steps=sample_count).round().to(dtype=torch.long).tolist()
+        frames_np = reader.get_frames_nhwc_uint8(indices)
+        frames = [Image.fromarray(frame) for frame in frames_np]
+
+        source_fps = reader.get_avg_fps()
+        average_stride = (indices[-1] - indices[0]) / max(len(indices) - 1, 1) if len(indices) > 1 else 1.0
+        effective_fps = source_fps / max(average_stride, 1.0)
+        decoded = (frames, float(effective_fps))
+        if self.video_cache_size > 0:
+            self._video_cache[video_path] = decoded
+            self._video_cache.move_to_end(video_path)
+            while len(self._video_cache) > self.video_cache_size:
+                self._video_cache.popitem(last=False)
+        return decoded
+
+    def _sharegpt_to_openai(self, item: dict) -> list[dict]:
+        conversations = item.get("conversations", [])
+        video_path = item.get("video")
+        frames, fps = self._decode_video(video_path)
+        messages: list[dict] = []
+        video_inserted = False
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+
+        for turn in conversations:
+            role = "user" if turn["from"] == "human" else "assistant"
+            text = re.sub(r"(\n)?</?(image|video)>(\n)?", "", turn["value"]).strip()
+            if role == "user" and not video_inserted:
+                content: Any = [
+                    {"type": "video", "video": frames, "fps": fps},
+                    {"type": "text", "text": text},
+                ]
+                video_inserted = True
+            else:
+                content = text
+            messages.append({"role": role, "content": content})
+        return messages
+
+
+def _wts_dataloader(
+    *,
+    annotation_env: str,
+    media_env: str,
+    limit_env: str,
+    shuffle: bool,
+) -> LazyDict:
+    return L(CosmosDataLoader)(
+        distributor=L(MapDistributor)(
+            dataset=L(WTSLlavaDataset)(
+                annotation_path=f"${{oc.env:{annotation_env}}}",
+                media_path=f"${{oc.env:{media_env}}}",
+                limit=f"${{oc.env:{limit_env},''}}",
+            ),
+            shuffle=shuffle,
+            seed=42,
+            name="train" if shuffle else "val",
+        ),
+        processor=L(WTSProcessor)(
+            processor=L(build_processor)(
+                tokenizer_type="${model.config.policy.backbone.model_name}",
+                config_variant="hf",
+            ),
+            ignore_index=IGNORE_INDEX,
+            num_video_frames=8,
+            video_cache_size=8,
+            system_prompt=("You are a helpful assistant that can answer questions about a street-view CCTV footage."),
+        ),
+        batcher=L(PoolPackingBatcher)(
+            max_tokens="${data_setting.max_tokens}",
+            pool_size=16 if shuffle else 1,
+            max_batch_size=1,
+            long_threshold=6400,
+        ),
+        collator=L(VLMCollator)(),
+        num_workers=0,
+        prefetch_factor=None,
+        persistent_workers=False,
+        pin_memory=False,
+    )
+
+
+wts_vlm = LazyDict(
+    dict(
+        defaults=[
+            {"override /checkpoint": "local"},
+            {"override /data_train": None},
+            {"override /data_val": None},
+            {"override /model": "vlm_fsdp"},
+            {"override /vlm_policy": "qwen3_vl_8b_instruct"},
+            {"override /callbacks": ["basic_vlm", "basic_log"]},
+            "_self_",
+        ],
+        job=dict(
+            project="cosmos3_reasoner",
+            group="wts_sft",
+            wandb_mode="disabled",
+        ),
+        trainer=dict(
+            callbacks=dict(
+                dataloader_state=L(CosmosDataLoaderStateCallback)(),
+                tao=dict(
+                    enabled=True,
+                    logging_interval=1,
+                    validation_heartbeat_interval=1,
+                ),
+            ),
+            max_iter=10,
+            logging_iter=1,
+            run_validation=True,
+            validation_iter=10,
+            max_val_iter=10,
+            run_validation_on_start=False,
+            grad_accum_iter=1,
+        ),
+        optimizer=dict(
+            lr=1.0e-4,
+            fused=True,
+            weight_decay=0.01,
+            betas=[0.9, 0.999],
+            lr_multipliers={"model.visual": 1.0},
+        ),
+        model=dict(
+            config=dict(
+                policy=dict(
+                    model_max_length=81920,
+                    qwen_max_video_token_length=8192,
+                ),
+                freeze=dict(trainable_params=[".*"]),
+                parallelism=dict(
+                    data_parallel_shard_degree=4,
+                    data_parallel_replicate_degree=1,
+                ),
+            ),
+        ),
+        data_setting=dict(
+            max_tokens=81920,
+            qwen_max_video_token_length=8192,
+        ),
+        checkpoint=dict(
+            save_iter=100,
+            load_from_object_store=dict(enabled=False, credentials="", bucket=""),
+            save_to_object_store=dict(enabled=False, credentials="", bucket=""),
+        ),
+        dataloader_train=_wts_dataloader(
+            annotation_env="WTS_TRAIN_ANNOTATION",
+            media_env="WTS_TRAIN_MEDIA",
+            limit_env="WTS_TRAIN_LIMIT",
+            shuffle=True,
+        ),
+        dataloader_val=_wts_dataloader(
+            annotation_env="WTS_VAL_ANNOTATION",
+            media_env="WTS_VAL_MEDIA",
+            limit_env="WTS_VAL_LIMIT",
+            shuffle=False,
+        ),
+        upload_reproducible_setup=False,
+    ),
+    flags={"allow_objects": True},
+)
+
+ConfigStore.instance().store(
+    group="experiment",
+    package="_global_",
+    name="wts_vlm",
+    node=wts_vlm,
+)
+
+
+# Edge uses the same WTS data contract but a different native HF backbone.
+# Keep it in this module so the dataloader worker callables retain a single
+# pickle identity when the reasoner config loader reloads experiment modules.
+wts_vlm_edge = deepcopy(wts_vlm)
+wts_vlm_edge["defaults"][4] = {"override /vlm_policy": "cosmos3_edge_reasoner"}
+wts_vlm_edge["job"]["group"] = "wts_edge_sft"
+wts_vlm_edge["optimizer"].pop("lr_multipliers", None)
+wts_vlm_edge["model"]["config"]["policy"]["model_max_length"] = 16000
+
+ConfigStore.instance().store(
+    group="experiment",
+    package="_global_",
+    name="wts_vlm_edge",
+    node=wts_vlm_edge,
+)

--- a/cosmos_framework/configs/base/reasoner/experiment/wts_vlm.py
+++ b/cosmos_framework/configs/base/reasoner/experiment/wts_vlm.py
@@ -20,6 +20,10 @@ from torch.utils.data import Dataset
 from cosmos_framework.callbacks.cosmos_dataloader_state import CosmosDataLoaderStateCallback
 from cosmos_framework.configs.base.reasoner.experiment.dataflow_roles import VLMCollator, VLMProcessor
 from cosmos_framework.data.generator.dataflow import CosmosDataLoader, MapDistributor, PoolPackingBatcher
+from cosmos_framework.data.generator.local_datasets.tao_vl_reason import (
+    TaoVlReasonDaftDataset,
+    apply_daft_chat_template,
+)
 from cosmos_framework.data.generator.processors import build_processor
 from cosmos_framework.utils.generator.torchcodec_video import TorchCodecVideoReader
 from cosmos_framework.utils.lazy_config import LazyCall as L
@@ -84,6 +88,7 @@ class WTSProcessor(VLMProcessor):
         num_video_frames: int = 8,
         video_cache_size: int = 8,
         system_prompt: str = "",
+        use_daft_chat_template: bool = False,
     ) -> None:
         super().__init__(processor=processor, ignore_index=ignore_index)
         if num_video_frames < 1:
@@ -93,6 +98,9 @@ class WTSProcessor(VLMProcessor):
         self.num_video_frames = num_video_frames
         self.video_cache_size = video_cache_size
         self.system_prompt = system_prompt
+        self.use_daft_chat_template = use_daft_chat_template
+        if self.use_daft_chat_template:
+            apply_daft_chat_template(processor)
         self._video_cache: OrderedDict[str, tuple[list[Image.Image], float]] = OrderedDict()
 
     def _decode_video(self, video_path: str) -> tuple[list[Image.Image], float]:
@@ -125,6 +133,23 @@ class WTSProcessor(VLMProcessor):
         return decoded
 
     def _sharegpt_to_openai(self, item: dict) -> list[dict]:
+        if "messages" in item:
+            messages = deepcopy(item["messages"])
+            for message in messages:
+                content = message.get("content")
+                if not isinstance(content, list):
+                    continue
+                for part in content:
+                    if part.get("type") != "video":
+                        continue
+                    video_path = part.get("video")
+                    if not isinstance(video_path, str):
+                        raise TypeError("DAFT video content must contain a string path")
+                    frames, fps = self._decode_video(video_path)
+                    part["video"] = frames
+                    part["fps"] = fps
+            return messages
+
         conversations = item.get("conversations", [])
         video_path = item.get("video")
         frames, fps = self._decode_video(video_path)
@@ -175,6 +200,49 @@ def _wts_dataloader(
             num_video_frames=8,
             video_cache_size=8,
             system_prompt=("You are a helpful assistant that can answer questions about a street-view CCTV footage."),
+        ),
+        batcher=L(PoolPackingBatcher)(
+            max_tokens="${data_setting.max_tokens}",
+            pool_size=16 if shuffle else 1,
+            max_batch_size=1,
+            long_threshold=6400,
+        ),
+        collator=L(VLMCollator)(),
+        num_workers=0,
+        prefetch_factor=None,
+        persistent_workers=False,
+        pin_memory=False,
+    )
+
+
+def _aetc_daft_dataloader(*, split: str, shuffle: bool) -> LazyDict:
+    annotation_env = f"AETC_{split.upper()}_ANNOTATIONS"
+    media_env = f"AETC_{split.upper()}_MEDIA"
+    limit_env = f"AETC_{split.upper()}_LIMIT"
+    return L(CosmosDataLoader)(
+        distributor=L(MapDistributor)(
+            dataset=L(TaoVlReasonDaftDataset)(
+                annotation_paths=f"${{oc.env:{annotation_env}}}",
+                media_root=f"${{oc.env:{media_env}}}",
+                response_mode="hybrid" if split == "train" else "answer",
+                system_prompt="${oc.env:AETC_SYSTEM_PROMPT,''}",
+                vision_kwargs={},
+                max_samples=f"${{oc.env:{limit_env},''}}",
+            ),
+            shuffle=shuffle,
+            seed=42,
+            name=split,
+        ),
+        processor=L(WTSProcessor)(
+            processor=L(build_processor)(
+                tokenizer_type="${model.config.policy.backbone.model_name}",
+                config_variant="hf",
+            ),
+            ignore_index=IGNORE_INDEX,
+            num_video_frames=8,
+            video_cache_size=8,
+            system_prompt="",
+            use_daft_chat_template=True,
         ),
         batcher=L(PoolPackingBatcher)(
             max_tokens="${data_setting.max_tokens}",
@@ -274,6 +342,21 @@ ConfigStore.instance().store(
     package="_global_",
     name="wts_vlm",
     node=wts_vlm,
+)
+
+
+# Internal TAO AETC path: keep Framework's trainer/model implementation while
+# consuming the same DAFT dataset and Qwen chat-template contract as Cosmos-RL.
+aetc_daft_vlm = deepcopy(wts_vlm)
+aetc_daft_vlm["job"]["group"] = "aetc_daft_sft"
+aetc_daft_vlm["dataloader_train"] = _aetc_daft_dataloader(split="train", shuffle=True)
+aetc_daft_vlm["dataloader_val"] = _aetc_daft_dataloader(split="val", shuffle=False)
+
+ConfigStore.instance().store(
+    group="experiment",
+    package="_global_",
+    name="aetc_daft_vlm",
+    node=aetc_daft_vlm,
 )
 
 

--- a/cosmos_framework/configs/base/reasoner/experiment/wts_vlm_test.py
+++ b/cosmos_framework/configs/base/reasoner/experiment/wts_vlm_test.py
@@ -4,10 +4,46 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 
 import pytest
 
-from cosmos_framework.configs.base.reasoner.experiment.wts_vlm import WTSLlavaDataset, wts_vlm_edge
+from cosmos_framework.configs.base.reasoner.experiment.wts_vlm import (
+    WTSLlavaDataset,
+    aetc_daft_vlm,
+    wts_vlm_edge,
+)
+from cosmos_framework.data.generator.local_datasets.tao_vl_reason import (
+    TaoVlReasonDaftDataset,
+    apply_daft_chat_template,
+    parse_path_list,
+)
+
+
+def _install_fake_daft(monkeypatch) -> list[object]:
+    calls: list[object] = []
+
+    class FakeDataset:
+        def __init__(self, **kwargs) -> None:
+            calls.append(kwargs)
+            self._raw_length = 2
+
+        def __getitem__(self, index: int) -> list[dict]:
+            return [{"role": "assistant", "content": f"daft-{index}"}]
+
+    def fake_template(processor) -> None:
+        calls.append(processor)
+
+    package = types.ModuleType("nvidia_tao_daft")
+    datasets = types.ModuleType("nvidia_tao_daft.datasets")
+    module = types.ModuleType("nvidia_tao_daft.datasets.tao_vl_reason_v1_0")
+    module.TaoVlReasonV1_0CosmosRLConversationDataset = FakeDataset
+    module.apply_chat_template_override = fake_template
+    monkeypatch.setitem(sys.modules, "nvidia_tao_daft", package)
+    monkeypatch.setitem(sys.modules, "nvidia_tao_daft.datasets", datasets)
+    monkeypatch.setitem(sys.modules, "nvidia_tao_daft.datasets.tao_vl_reason_v1_0", module)
+    return calls
 
 
 def test_wts_dataset_resolves_video_paths_and_limit(tmp_path) -> None:
@@ -54,3 +90,36 @@ def test_wts_edge_uses_native_edge_policy() -> None:
     assert wts_vlm_edge["defaults"][4] == {"override /vlm_policy": "cosmos3_edge_reasoner"}
     assert "lr_multipliers" not in wts_vlm_edge["optimizer"]
     assert wts_vlm_edge["model"]["config"]["policy"]["model_max_length"] == 16000
+
+
+def test_daft_dataset_matches_internal_hybrid_index_order(monkeypatch) -> None:
+    calls = _install_fake_daft(monkeypatch)
+    dataset = TaoVlReasonDaftDataset(
+        annotation_paths='["bcq.json", "mcq.json"]',
+        media_root="/data/aetc",
+        response_mode="hybrid",
+        system_prompt="system",
+    )
+
+    assert len(dataset) == 4
+    assert [dataset[index]["messages"][0]["content"] for index in range(4)] == [
+        "daft-0",
+        "daft-2",
+        "daft-1",
+        "daft-3",
+    ]
+    assert calls[0]["annotation_paths"] == ["bcq.json", "mcq.json"]
+    assert calls[0]["media_roots"] == "/data/aetc"
+
+
+def test_daft_chat_template_targets_wrapped_hf_processor(monkeypatch) -> None:
+    calls = _install_fake_daft(monkeypatch)
+    wrapped = types.SimpleNamespace(processor=object())
+    apply_daft_chat_template(wrapped)
+    assert calls == [wrapped.processor]
+
+
+def test_daft_recipe_and_json_path_parser() -> None:
+    assert parse_path_list('["a.json", "b.json"]') == ["a.json", "b.json"]
+    assert aetc_daft_vlm["job"]["group"] == "aetc_daft_sft"
+    assert aetc_daft_vlm["dataloader_train"]["processor"]["use_daft_chat_template"]

--- a/cosmos_framework/configs/base/reasoner/experiment/wts_vlm_test.py
+++ b/cosmos_framework/configs/base/reasoner/experiment/wts_vlm_test.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cosmos_framework.configs.base.reasoner.experiment.wts_vlm import WTSLlavaDataset, wts_vlm_edge
+
+
+def test_wts_dataset_resolves_video_paths_and_limit(tmp_path) -> None:
+    media = tmp_path / "videos"
+    media.mkdir()
+    (media / "clip.mp4").write_bytes(b"video")
+    annotations = tmp_path / "annotations.json"
+    annotations.write_text(
+        json.dumps(
+            [
+                {
+                    "video": "clip.mp4",
+                    "conversations": [
+                        {"from": "human", "value": "<video> what happens?"},
+                        {"from": "gpt", "value": "A car stops."},
+                    ],
+                },
+                {
+                    "video": "clip.mp4",
+                    "conversations": [
+                        {"from": "human", "value": "<video> what happens next?"},
+                        {"from": "gpt", "value": "Traffic moves."},
+                    ],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    dataset = WTSLlavaDataset(str(annotations), str(media), limit="1")
+    assert len(dataset) == 1
+    assert dataset[0]["video"] == str(media / "clip.mp4")
+
+
+def test_wts_dataset_rejects_invalid_record(tmp_path) -> None:
+    annotations = tmp_path / "annotations.json"
+    annotations.write_text(json.dumps([{"video": "clip.mp4"}]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="conversation"):
+        WTSLlavaDataset(str(annotations), str(tmp_path))
+
+
+def test_wts_edge_uses_native_edge_policy() -> None:
+    assert wts_vlm_edge["defaults"][4] == {"override /vlm_policy": "cosmos3_edge_reasoner"}
+    assert "lr_multipliers" not in wts_vlm_edge["optimizer"]
+    assert wts_vlm_edge["model"]["config"]["policy"]["model_max_length"] == 16000

--- a/cosmos_framework/configs/toml_config/sft_config.py
+++ b/cosmos_framework/configs/toml_config/sft_config.py
@@ -357,8 +357,7 @@ class ModelConfig(BaseModel):
     lora_rank: int = Field(
         default=16,
         description=(
-            "LoRA rank `r`. Adapter shape is (rank × hidden_dim) per target "
-            "module. Standard values are 4, 8, 16, 32."
+            "LoRA rank `r`. Adapter shape is (rank × hidden_dim) per target module. Standard values are 4, 8, 16, 32."
         ),
     )
     lora_alpha: int = Field(
@@ -379,9 +378,7 @@ class ModelConfig(BaseModel):
     ema: EMAConfig = Field(default_factory=EMAConfig)
     parallelism: ParallelismConfig = Field(default_factory=ParallelismConfig)
     compile: CompileConfig = Field(default_factory=CompileConfig)
-    activation_checkpointing: ActivationCheckpointingConfig = Field(
-        default_factory=ActivationCheckpointingConfig
-    )
+    activation_checkpointing: ActivationCheckpointingConfig = Field(default_factory=ActivationCheckpointingConfig)
     tokenizer: ModelTokenizerConfig = Field(default_factory=ModelTokenizerConfig)
     backbone: BackboneConfig = Field(default_factory=BackboneConfig)
 
@@ -473,15 +470,12 @@ class SchedulerConfig(BaseModel):
     )
     f_start: list[float] = Field(
         default_factory=lambda: [1.0e-6],
-        description=(
-            "Initial LR multiplier at step 0, before warmup ramps up."
-        ),
+        description=("Initial LR multiplier at step 0, before warmup ramps up."),
     )
     verbosity_interval: int = Field(
         default=0,
         description=(
-            "How often the scheduler logs the current LR (in optimizer "
-            "steps). 0 = silent. VFM only — skipped on VLM."
+            "How often the scheduler logs the current LR (in optimizer steps). 0 = silent. VFM only — skipped on VLM."
         ),
     )
     warm_up_steps: list[int] = Field(
@@ -533,8 +527,7 @@ class GradClipCallback(BaseModel):
     clip_norm: float = Field(
         default=1.0,
         description=(
-            "Maximum global L2 norm of the gradient. Steps with a larger "
-            "norm are rescaled so ||grad|| ≤ clip_norm."
+            "Maximum global L2 norm of the gradient. Steps with a larger norm are rescaled so ||grad|| ≤ clip_norm."
         ),
     )
     force_finite: bool = Field(
@@ -547,8 +540,37 @@ class GradClipCallback(BaseModel):
     )
 
 
+class TAOStatusCallbackConfig(BaseModel):
+    """TAO-compatible lifecycle and training/validation metric logging."""
+
+    model_config = _PYDANTIC_MODEL_CONFIG
+
+    enabled: bool = Field(default=False, description="Enable TAO status.json logging.")
+    status_file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Explicit status.json path. When unset, TAO_JOB_ID/TAO_RESULTS_ROOT, "
+            "legacy TAO API variables, then job.path_local are used."
+        ),
+    )
+    experiment_name: str = Field(
+        default="",
+        description="TAO component name. Empty uses job.name.",
+    )
+    logging_interval: int = Field(
+        default=1,
+        ge=1,
+        description="Multiplier applied to trainer.logging_iter for TAO training records.",
+    )
+    validation_heartbeat_interval: int = Field(
+        default=1,
+        ge=1,
+        description="Write validation progress every N validation batches.",
+    )
+
+
 class TrainerCallbacksConfig(BaseModel):
-    """Only the two callbacks the schema currently surfaces. The full
+    """Callbacks surfaced by the structured TOML schema. The full
     callbacks dict (norm_monitor, mfu, heart_beat, …) stays in the
     experiment Python.
     """
@@ -557,6 +579,7 @@ class TrainerCallbacksConfig(BaseModel):
 
     compile_tokenizer: CompileTokenizerCallback = Field(default_factory=CompileTokenizerCallback)
     grad_clip: GradClipCallback = Field(default_factory=GradClipCallback)
+    tao: TAOStatusCallbackConfig = Field(default_factory=TAOStatusCallbackConfig)
 
 
 class TrainerConfig(BaseModel):
@@ -567,8 +590,7 @@ class TrainerConfig(BaseModel):
     distributed_parallelism: str = Field(
         default="fsdp",
         description=(
-            "Distributed strategy. 'fsdp' (the only supported value today) "
-            "routes through cosmos's FSDP wrapper."
+            "Distributed strategy. 'fsdp' (the only supported value today) routes through cosmos's FSDP wrapper."
         ),
     )
     grad_accum_iter: int = Field(
@@ -586,6 +608,39 @@ class TrainerConfig(BaseModel):
     max_iter: int = Field(
         default=500,
         description="Total number of optimizer steps the run will execute.",
+    )
+    num_epochs: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Number of complete training epochs. Requires steps_per_epoch and takes priority over max_iter.",
+    )
+    steps_per_epoch: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optimizer updates in one training epoch.",
+    )
+    max_val_iter: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Maximum validation batches per validation pass. None consumes a finite validation loader.",
+    )
+    run_validation: bool = Field(
+        default=False,
+        description="Enable validation during training.",
+    )
+    validation_iter: int = Field(
+        default=100,
+        ge=1,
+        description="Run validation every N optimizer steps.",
+    )
+    validation_freq_in_epoch: int = Field(
+        default=0,
+        ge=0,
+        description="Validate every N completed epochs; 0 uses validation_iter.",
+    )
+    run_validation_on_start: bool = Field(
+        default=False,
+        description="Run one validation pass before the first training step.",
     )
     callbacks: TrainerCallbacksConfig = Field(default_factory=TrainerCallbacksConfig)
 
@@ -617,6 +672,11 @@ class CheckpointConfig(BaseModel):
     save_iter: int = Field(
         default=100,
         description="Save a new checkpoint every N optimizer steps.",
+    )
+    save_freq_in_epoch: int = Field(
+        default=0,
+        ge=0,
+        description="Save every N completed epochs; 0 uses save_iter.",
     )
 
 
@@ -658,10 +718,7 @@ class DataloaderTrainConfig(BaseModel):
     )
     seed: int = Field(
         default=42,
-        description=(
-            "Dataloader RNG seed. Skipped on VLM (CosmosDataLoader has "
-            "no seed ctor kwarg there)."
-        ),
+        description=("Dataloader RNG seed. Skipped on VLM (CosmosDataLoader has no seed ctor kwarg there)."),
     )
 
 
@@ -746,8 +803,7 @@ def load_experiment_from_toml(
         base_config_path = TASK_TO_BASE_CONFIG[task]
     except KeyError as e:
         raise ValueError(
-            f"{toml_path}: [job].task={task!r} is not supported. "
-            f"Valid values: {sorted(TASK_TO_BASE_CONFIG)}"
+            f"{toml_path}: [job].task={task!r} is not supported. Valid values: {sorted(TASK_TO_BASE_CONFIG)}"
         ) from e
 
     overrides = build_hydra_overrides(raw)
@@ -759,10 +815,7 @@ def load_experiment_from_toml(
             if not o or o == "--":
                 continue
             if "=" not in o:
-                raise ValueError(
-                    f"extra override {o!r} must be Hydra dotted-path syntax "
-                    f"(e.g. 'optimizer.lr=1e-5')."
-                )
+                raise ValueError(f"extra override {o!r} must be Hydra dotted-path syntax (e.g. 'optimizer.lr=1e-5').")
             overrides.append(o)
 
     # Import lazily so this module stays cheap to import in non-training contexts.

--- a/cosmos_framework/configs/toml_config/sft_config_test.py
+++ b/cosmos_framework/configs/toml_config/sft_config_test.py
@@ -76,6 +76,24 @@ class TestSchemaValidation:
                 }
             )
 
+    def test_native_epoch_schedule_fields_validate(self) -> None:
+        cfg = SFTExperimentConfig.model_validate(
+            {
+                "job": {"task": "vlm", "experiment": "wts_vlm"},
+                "trainer": {
+                    "num_epochs": 2,
+                    "steps_per_epoch": 108,
+                    "validation_freq_in_epoch": 1,
+                },
+                "checkpoint": {"save_freq_in_epoch": 2},
+            }
+        )
+
+        assert cfg.trainer.num_epochs == 2
+        assert cfg.trainer.steps_per_epoch == 108
+        assert cfg.trainer.validation_freq_in_epoch == 1
+        assert cfg.checkpoint.save_freq_in_epoch == 2
+
 
 # --------------------------------------------------------------------------- #
 # 2. build_hydra_overrides must NOT emit [custom] as per-leaf overrides        #

--- a/cosmos_framework/data/generator/local_datasets/tao_vl_reason.py
+++ b/cosmos_framework/data/generator/local_datasets/tao_vl_reason.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""DAFT-backed ``tao-vl-reason-v1.0`` dataset adapter for Framework SFT."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from torch.utils.data import Dataset
+
+ResponseMode = Literal["think", "answer", "hybrid"]
+
+
+def parse_path_list(value: str | list[str]) -> list[str]:
+    """Resolve a path or JSON-encoded path list supplied through Hydra/env."""
+    if isinstance(value, list):
+        paths = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            paths = []
+        elif stripped.startswith("["):
+            paths = json.loads(stripped)
+        else:
+            paths = [stripped]
+    else:
+        raise TypeError(f"annotation_paths must be a string or list, got {type(value).__name__}")
+    if not paths or not all(isinstance(path, str) and path.strip() for path in paths):
+        raise ValueError("annotation_paths must contain at least one non-empty path")
+    return [path.strip() for path in paths]
+
+
+def _optional_positive_int(value: int | str | None) -> int | None:
+    if value in (None, ""):
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+class TaoVlReasonDaftDataset(Dataset):
+    """Expose DAFT conversations through Cosmos Framework's map dataflow.
+
+    The index mapping intentionally matches the internal Cosmos-RL DAFT hook:
+    hybrid mode interleaves answer and reasoning targets for every raw item.
+    """
+
+    def __init__(
+        self,
+        annotation_paths: str | list[str],
+        media_root: str | list[str] | None = None,
+        response_mode: ResponseMode = "answer",
+        system_prompt: str = "",
+        vision_kwargs: dict[str, Any] | None = None,
+        max_samples: int | str | None = None,
+        sample_stride: int = 1,
+        sample_offset: int = 0,
+    ) -> None:
+        try:
+            from nvidia_tao_daft.datasets.tao_vl_reason_v1_0 import (
+                TaoVlReasonV1_0CosmosRLConversationDataset,
+            )
+        except ImportError as exc:
+            raise ImportError("nvidia-tao-daft>=2.9.1 is required for the AETC DAFT recipe") from exc
+
+        paths = parse_path_list(annotation_paths)
+        if isinstance(media_root, str) and media_root.strip().startswith("["):
+            media_root = parse_path_list(media_root)
+        if response_mode not in {"think", "answer", "hybrid"}:
+            raise ValueError(f"unsupported response_mode: {response_mode!r}")
+        if sample_stride < 1:
+            raise ValueError("sample_stride must be positive")
+        if sample_offset < 0:
+            raise ValueError("sample_offset must be non-negative")
+
+        self.dataset = TaoVlReasonV1_0CosmosRLConversationDataset(
+            annotation_paths=paths,
+            media_roots=media_root,
+            system_prompt=system_prompt,
+            vision_kwargs=vision_kwargs or {},
+            response_mode=response_mode,
+        )
+        self.response_mode = response_mode
+        self.sample_stride = sample_stride
+        self.sample_offset = sample_offset
+        self.max_samples = _optional_positive_int(max_samples)
+        self.raw_length = int(getattr(self.dataset, "_raw_length"))
+
+    def _subsampled_raw_length(self) -> int:
+        if self.sample_offset >= self.raw_length:
+            return 0
+        return ((self.raw_length - self.sample_offset - 1) // self.sample_stride) + 1
+
+    def __len__(self) -> int:
+        length = self._subsampled_raw_length()
+        if self.response_mode == "hybrid":
+            length *= 2
+        if self.max_samples is not None:
+            length = min(length, self.max_samples)
+        return length
+
+    def __getitem__(self, index: int) -> dict[str, list[dict[str, Any]]]:
+        if not 0 <= index < len(self):
+            raise IndexError(index)
+        if self.response_mode == "hybrid":
+            raw_index = self.sample_offset + (index // 2) * self.sample_stride
+            daft_index = raw_index if index % 2 == 0 else self.raw_length + raw_index
+        else:
+            daft_index = self.sample_offset + index * self.sample_stride
+        return {"messages": self.dataset[daft_index]}
+
+
+def apply_daft_chat_template(processor: Any) -> None:
+    """Apply DAFT's Qwen3-VL Instruct template to a Framework processor."""
+    try:
+        from nvidia_tao_daft.datasets.tao_vl_reason_v1_0 import (
+            apply_chat_template_override,
+        )
+    except ImportError as exc:
+        raise ImportError("nvidia-tao-daft>=2.9.1 is required for the AETC DAFT recipe") from exc
+
+    huggingface_processor = getattr(processor, "processor", processor)
+    apply_chat_template_override(huggingface_processor)

--- a/cosmos_framework/scripts/train.py
+++ b/cosmos_framework/scripts/train.py
@@ -30,15 +30,14 @@ import traceback
 import torch
 from loguru import logger as logging
 
-from cosmos_framework.utils.config import Config
-from cosmos_framework.utils.lazy_config import LazyConfig, instantiate
-from cosmos_framework.utils.serialization import to_yaml
+from cosmos_framework.configs.toml_config.sft_config import load_experiment_from_toml
 from cosmos_framework.utils import distributed
+from cosmos_framework.utils.config import Config
 from cosmos_framework.utils.context_managers import data_loader_init, distributed_init, model_init
 from cosmos_framework.utils.launch import log_reproducible_setup
+from cosmos_framework.utils.lazy_config import LazyConfig, instantiate
+from cosmos_framework.utils.serialization import to_yaml
 from cosmos_framework.utils.training_telemetry import telemetry
-from cosmos_framework.configs.toml_config.sft_config import load_experiment_from_toml
-
 
 # ---------------------------------------------------------------------------
 # --deterministic: mirrors launch_vfm.sh determinism settings.
@@ -216,12 +215,17 @@ def launch(config: Config, args: argparse.Namespace) -> None:
         dataloader_train = instantiate(config.dataloader_train)
         dataloader_val = instantiate(config.dataloader_val)
 
-    # Start training
-    trainer.train(
-        model,
-        dataloader_train,
-        dataloader_val,
-    )
+    # Start training. Give callbacks a final failure hook so external
+    # orchestrators (including TAO) receive a terminal status record.
+    try:
+        trainer.train(
+            model,
+            dataloader_train,
+            dataloader_val,
+        )
+    except BaseException as error:
+        trainer.callbacks.on_exception(error)
+        raise
 
 
 if __name__ == "__main__":

--- a/cosmos_framework/trainer/__init__.py
+++ b/cosmos_framework/trainer/__init__.py
@@ -11,9 +11,13 @@ import torch
 import torch.distributed as dist
 import torch.utils.data
 
-from cosmos_framework.utils.flags import INTERNAL
 from cosmos_framework.utils.context_managers import distributed_init
-from cosmos_framework.utils.profiling import maybe_enable_memory_snapshot, maybe_enable_nsys_profiling, maybe_enable_profiling
+from cosmos_framework.utils.flags import INTERNAL
+from cosmos_framework.utils.profiling import (
+    maybe_enable_memory_snapshot,
+    maybe_enable_nsys_profiling,
+    maybe_enable_profiling,
+)
 
 try:
     from megatron.core import parallel_state
@@ -23,12 +27,11 @@ except ImportError:
     USE_MEGATRON = False
 
 
-from cosmos_framework.utils.lazy_config import LazyConfig, instantiate
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import callback, distributed, ema, log, misc
 from cosmos_framework.utils.checkpointer import Checkpointer
+from cosmos_framework.utils.lazy_config import LazyConfig, instantiate
 from cosmos_framework.utils.misc import StragglerDetectorV2
-
 
 
 class ImaginaireTrainer:
@@ -51,6 +54,21 @@ class ImaginaireTrainer:
         """
         super().__init__()
         self.config = config
+        steps_per_epoch = getattr(config.trainer, "steps_per_epoch", None)
+        num_epochs = getattr(config.trainer, "num_epochs", None)
+        self.steps_per_epoch = int(steps_per_epoch) if steps_per_epoch else None
+        self.num_epochs = int(num_epochs) if num_epochs else None
+        if (self.steps_per_epoch is None) != (self.num_epochs is None):
+            raise ValueError("trainer.steps_per_epoch and trainer.num_epochs must be configured together")
+        self.max_iterations = (
+            self.steps_per_epoch * self.num_epochs
+            if self.steps_per_epoch is not None and self.num_epochs is not None
+            else int(config.trainer.max_iter)
+        )
+        if int(getattr(config.checkpoint, "save_freq_in_epoch", 0)) > 0 and self.steps_per_epoch is None:
+            raise ValueError("checkpoint.save_freq_in_epoch requires trainer.num_epochs and trainer.steps_per_epoch")
+        if int(getattr(config.trainer, "validation_freq_in_epoch", 0)) > 0 and self.steps_per_epoch is None:
+            raise ValueError("trainer.validation_freq_in_epoch requires trainer.num_epochs and trainer.steps_per_epoch")
         # Set up the distributed computing environment.
         with distributed_init():
             distributed.init()
@@ -276,7 +294,7 @@ class ImaginaireTrainer:
                     finally:
                         self.callbacks.on_after_dataloading(iteration)
                     # If max_iter is reached, exit the training loop.
-                    if iteration >= self.config.trainer.max_iter:
+                    if iteration >= self.max_iterations:
                         _end_training = True
                         break
                     # Move all tensors in the data batch to GPU device.
@@ -306,11 +324,39 @@ class ImaginaireTrainer:
                     # Do the following when an actual optimizer (update) step has been made.
                     iteration += 1
                     # Save checkpoint.
-                    if iteration % self.config.checkpoint.save_iter == 0:
-                        self.checkpointer.save(model, optimizer, scheduler, grad_scaler, iteration=iteration)
+                    completed_epoch = (
+                        iteration // self.steps_per_epoch
+                        if self.steps_per_epoch and iteration % self.steps_per_epoch == 0
+                        else None
+                    )
+                    save_freq_in_epoch = int(getattr(self.config.checkpoint, "save_freq_in_epoch", 0))
+                    epoch_save_due = bool(
+                        completed_epoch is not None
+                        and save_freq_in_epoch > 0
+                        and completed_epoch % save_freq_in_epoch == 0
+                    )
+                    iter_save_due = save_freq_in_epoch == 0 and iteration % self.config.checkpoint.save_iter == 0
+                    if epoch_save_due or iter_save_due:
+                        self.checkpointer.save(
+                            model,
+                            optimizer,
+                            scheduler,
+                            grad_scaler,
+                            iteration=iteration,
+                            epoch=completed_epoch if epoch_save_due else None,
+                        )
                     self.callbacks.on_training_step_end(model, data_batch, output_batch, loss, iteration=iteration)
                     # Validation.
-                    if self.config.trainer.run_validation and iteration % self.config.trainer.validation_iter == 0:
+                    validation_freq_in_epoch = int(getattr(self.config.trainer, "validation_freq_in_epoch", 0))
+                    epoch_validation_due = bool(
+                        completed_epoch is not None
+                        and validation_freq_in_epoch > 0
+                        and completed_epoch % validation_freq_in_epoch == 0
+                    )
+                    iter_validation_due = (
+                        validation_freq_in_epoch == 0 and iteration % self.config.trainer.validation_iter == 0
+                    )
+                    if self.config.trainer.run_validation and (epoch_validation_due or iter_validation_due):
                         self.validate(model, dataloader_val, iteration=iteration)
                     # This iteration is successful; reset the timeout signal.
                     signal.alarm(self.config.trainer.timeout_period)
@@ -326,8 +372,24 @@ class ImaginaireTrainer:
         log.success("Done with training.")
         if sm_carveout:
             torch._C._set_sm_carveout_experimental(None)
-        if iteration % self.config.checkpoint.save_iter != 0:
-            self.checkpointer.save(model, optimizer, scheduler, grad_scaler, iteration=iteration)
+        final_epoch = (
+            iteration // self.steps_per_epoch
+            if self.steps_per_epoch and iteration % self.steps_per_epoch == 0
+            else None
+        )
+        save_freq_in_epoch = int(getattr(self.config.checkpoint, "save_freq_in_epoch", 0))
+        final_already_saved = (
+            final_epoch is not None and save_freq_in_epoch > 0 and final_epoch % save_freq_in_epoch == 0
+        ) or (save_freq_in_epoch == 0 and iteration % self.config.checkpoint.save_iter == 0)
+        if not final_already_saved:
+            self.checkpointer.save(
+                model,
+                optimizer,
+                scheduler,
+                grad_scaler,
+                iteration=iteration,
+                epoch=final_epoch if save_freq_in_epoch > 0 else None,
+            )
         self.callbacks.on_train_end(model, iteration=iteration)
         self.checkpointer.finalize()
         distributed.barrier()

--- a/cosmos_framework/utils/callback.py
+++ b/cosmos_framework/utils/callback.py
@@ -15,10 +15,9 @@ import torch.utils.data
 import tqdm
 import wandb
 
-from cosmos_framework.utils.lazy_config import instantiate
 from cosmos_framework.utils import distributed, log, misc, wandb_util
+from cosmos_framework.utils.lazy_config import instantiate
 from cosmos_framework.utils.misc import get_local_tensor_if_DTensor
-
 
 try:
     from megatron.core import parallel_state
@@ -27,9 +26,9 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from cosmos_framework.utils.config import Config
     from cosmos_framework.model._base import ImaginaireModel
     from cosmos_framework.trainer import ImaginaireTrainer
+    from cosmos_framework.utils.config import Config
 
 
 class CallBackGroup:
@@ -303,6 +302,10 @@ class Callback:
         pass
 
     def on_app_end(self) -> None:
+        pass
+
+    def on_exception(self, error: BaseException) -> None:
+        """Called when the application exits because of an uncaught exception."""
         pass
 
 

--- a/cosmos_framework/utils/checkpointer.py
+++ b/cosmos_framework/utils/checkpointer.py
@@ -61,6 +61,7 @@ class Checkpointer:
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         """Save network weights, optimizer parameters, scheduler parameters to a checkpoint.
 
@@ -73,7 +74,7 @@ class Checkpointer:
         """
         self.callbacks.on_save_checkpoint_start(model, iteration)
 
-        checkpoint_file = f"iter_{iteration:09}.pt"
+        checkpoint_file = f"epoch_{epoch}.pt" if epoch is not None else f"iter_{iteration:09}.pt"
 
         if distributed.get_rank() == 0:
             state_dict = dict(
@@ -116,7 +117,7 @@ class Checkpointer:
             if rank == 0:
                 self._write_latest_checkpoint_file(checkpoint_file)
             log.success(f"Saved checkpoint (local): {checkpoint_path}")
-            iteration = int(checkpoint_file.replace("iter_", "").replace(".pt", ""))
+            iteration = int(state_dict["iteration"])
             self.callbacks.on_save_checkpoint_success(iteration=iteration)
         except Exception as e:  # noqa: BLE001
             log.exception(f"Checkpoint failed to save (local): {e}")
@@ -138,7 +139,7 @@ class Checkpointer:
             if rank == 0:
                 self._write_latest_checkpoint_file(checkpoint_file)
             log.success(f"Saved checkpoint (object store): {checkpoint_path}")
-            iteration = int(checkpoint_file.replace("iter_", "").replace(".pt", ""))
+            iteration = int(state_dict["iteration"])
             self.callbacks.on_save_checkpoint_success(iteration=iteration)
         except Exception as e:  # noqa: BLE001
             log.exception(f"Checkpoint failed to upload (object store): {e}")
@@ -305,6 +306,7 @@ class MultiRankCheckpointer(Checkpointer):
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         """Save network weights, optimizer parameters, scheduler parameters to a checkpoint.
 
@@ -317,7 +319,7 @@ class MultiRankCheckpointer(Checkpointer):
         """
         # checkpoint_file = f"iter_{iteration:09}.pt"
         postfix, _, total_ema_num = model.get_ckpt_postfix()
-        checkpoint_file = f"iter_{iteration:09}{postfix}.pt"
+        checkpoint_file = f"epoch_{epoch}{postfix}.pt" if epoch is not None else f"iter_{iteration:09}{postfix}.pt"
         save_ranks = list(range(total_ema_num))
         for _rank in save_ranks:
             if distributed.get_rank() == _rank:

--- a/cosmos_framework/utils/config.py
+++ b/cosmos_framework/utils/config.py
@@ -288,6 +288,9 @@ class CheckpointConfig:
 
     # Save the checkpoint every N iterations.
     save_iter: int = 999999999
+    # Save every N completed epochs when trainer.steps_per_epoch is configured.
+    # A positive value takes priority over save_iter.
+    save_freq_in_epoch: int = 0
 
     # Load state_dict to the models in strict mode. If True, `allow_partial_load` in dcp
     # planner will be set to False. DCP will raise an error if there are missing keys.
@@ -453,6 +456,10 @@ class TrainerConfig:
     grad_scaler_args: dict = attrs.field(factory=lambda: dict(enabled=False))
     # Maximum number of iterations to train the model.
     max_iter: int = 999999999
+    # Native epoch schedule. When both values are positive, the trainer runs
+    # num_epochs * steps_per_epoch optimizer updates and reports epoch progress.
+    num_epochs: int | None = None
+    steps_per_epoch: int | None = None
     # Maximum number of iterations to validate the model. If None, validate on the entire dataset.
     max_val_iter: int | None = None
     # How often we log the training stats.
@@ -461,6 +468,9 @@ class TrainerConfig:
     run_validation: bool = True
     # How often we evaluate on the validation set.
     validation_iter: int = 999999999
+    # Validate every N completed epochs. A positive value takes priority over
+    # validation_iter when steps_per_epoch is configured.
+    validation_freq_in_epoch: int = 0
     # Whether to run the validation on the start of the training.
     run_validation_on_start: bool = False
     # Kill the process after N seconds since the last iteration (usually means dead job).

--- a/cosmos_framework/utils/reasoner/dcp_checkpointer.py
+++ b/cosmos_framework/utils/reasoner/dcp_checkpointer.py
@@ -55,8 +55,8 @@ from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
 
 from cosmos_framework.checkpoint.base import AbstractCheckpointer
 from cosmos_framework.checkpoint.s3_filesystem import S3StorageReader, S3StorageWriter
-from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.utils import callback, distributed, log, misc
+from cosmos_framework.utils.config import CheckpointConfig, JobConfig
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.utils.reasoner.model_wrapper import ModelWrapper
 from cosmos_framework.utils.reasoner.optimizer import OptimizersContainer
@@ -458,6 +458,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
         scheduler: torch.optim.lr_scheduler.LRScheduler,
         grad_scaler: torch.amp.GradScaler,
         iteration: int,
+        epoch: int | None = None,
     ) -> None:
         """Save network weights, optimizer parameters, scheduler parameters to a checkpoint.
 
@@ -471,7 +472,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
         del grad_scaler
         self.callbacks.on_save_checkpoint_start(model_parts, iteration)
 
-        checkpoint_file = f"iter_{iteration:09}"
+        checkpoint_file = f"epoch_{epoch}" if epoch is not None else f"iter_{iteration:09}"
         to_save_dict = {
             "model": ModelWrapper(model_parts).state_dict(),
             "optim": optimizer.state_dict(),
@@ -482,7 +483,7 @@ class DistributedCheckpointer(AbstractCheckpointer):
         self.callbacks.on_save_checkpoint(model_parts, state_dict=to_save_dict)
 
         for k in to_save_dict.keys():
-            output_dirname = os.path.join(self.save_dirname, f"iter_{iteration:09}/{k}")
+            output_dirname = os.path.join(self.save_dirname, checkpoint_file, k)
             to_save_dict[k] = (to_save_dict[k], output_dirname)
 
         if self.async_mode == AsyncMode.ASYNC_WITH_PINNED_MEM:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,8 @@
 
 set -e
 
-uv pip install --no-deps -e . || true
+if [[ -w /workspace/.venv ]]; then
+    uv pip install --no-deps -e . || true
+fi
 
 exec "$@"

--- a/examples/launch_sft_wts.sh
+++ b/examples/launch_sft_wts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+set -u
+
+: "${WTS_TRAIN_ANNOTATION:?Set WTS_TRAIN_ANNOTATION to the training JSON file}"
+: "${WTS_TRAIN_MEDIA:?Set WTS_TRAIN_MEDIA to the training video root}"
+: "${WTS_VAL_ANNOTATION:?Set WTS_VAL_ANNOTATION to the validation JSON file}"
+: "${WTS_VAL_MEDIA:?Set WTS_VAL_MEDIA to the validation video root}"
+: "${VLM_SAFETENSORS_PATH:?Set VLM_SAFETENSORS_PATH to converted Cosmos3-Nano safetensors}"
+
+export WTS_TRAIN_ANNOTATION WTS_TRAIN_MEDIA
+export WTS_VAL_ANNOTATION WTS_VAL_MEDIA
+export VLM_SAFETENSORS_PATH
+export WTS_TRAIN_LIMIT="${WTS_TRAIN_LIMIT:-}"
+export WTS_VAL_LIMIT="${WTS_VAL_LIMIT:-}"
+
+TOML_FILE="examples/toml/sft_config/wts_vlm.toml"
+EXTRA_DATASET_CHECK='
+[[ -f "$WTS_TRAIN_ANNOTATION" ]] || { echo "ERROR: training annotations not found: $WTS_TRAIN_ANNOTATION" >&2; exit 1; }
+[[ -d "$WTS_TRAIN_MEDIA" ]] || { echo "ERROR: training media root not found: $WTS_TRAIN_MEDIA" >&2; exit 1; }
+[[ -f "$WTS_VAL_ANNOTATION" ]] || { echo "ERROR: validation annotations not found: $WTS_VAL_ANNOTATION" >&2; exit 1; }
+[[ -d "$WTS_VAL_MEDIA" ]] || { echo "ERROR: validation media root not found: $WTS_VAL_MEDIA" >&2; exit 1; }
+[[ -d "$VLM_SAFETENSORS_PATH" ]] || { echo "ERROR: converted checkpoint not found: $VLM_SAFETENSORS_PATH" >&2; exit 1; }
+'
+
+TAIL_OVERRIDES=(
+    ${EXTRA_TAIL_OVERRIDES:-}
+)
+
+source "$(dirname "${BASH_SOURCE[0]}")/_sft_launcher_common.sh"

--- a/examples/toml/sft_config/aetc_daft_vlm.toml
+++ b/examples/toml/sft_config/aetc_daft_vlm.toml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# AETC dense SFT through the internal NVIDIA TAO DAFT data contract.
+# Required environment:
+#   AETC_TRAIN_ANNOTATIONS: JSON array of tao-vl-reason-v1.0 files
+#   AETC_TRAIN_MEDIA: shared media root for the training annotations
+#   AETC_VAL_ANNOTATIONS: JSON array of validation files
+#   AETC_VAL_MEDIA: shared media root for validation
+#   VLM_SAFETENSORS_PATH: Cosmos3-Nano checkpoint
+
+[job]
+task       = "vlm"
+experiment = "aetc_daft_vlm"
+project    = "cosmos3_reasoner"
+group      = "aetc_daft_sft"
+name       = "aetc_daft_vlm"
+wandb_mode = "disabled"
+
+[model]
+attn_implementation = "cosmos"
+precision = "bfloat16"
+
+[model.backbone]
+model_name = "${oc.env:VLM_SAFETENSORS_PATH}"
+safetensors_path = "${oc.env:VLM_SAFETENSORS_PATH}"
+
+[model.ema]
+enabled = false
+rate = 0.1
+iteration_shift = 0
+
+[model.parallelism]
+data_parallel_shard_degree = 4
+data_parallel_replicate_degree = 1
+context_parallel_shard_degree = 1
+cfg_parallel_shard_degree = 1
+
+[model.compile]
+enabled = false
+compile_dynamic = true
+
+[model.activation_checkpointing]
+mode = "full"
+save_ops_regex = ["fmha"]
+preserve_rng_state = true
+determinism_check = "default"
+
+[optimizer]
+betas = [0.9, 0.999]
+eps = 1.0e-6
+fused = true
+lr = 1.0e-5
+weight_decay = 0.01
+
+[scheduler]
+cycle_lengths = [10]
+f_max = [1.0]
+f_min = [1.0]
+f_start = [1.0]
+verbosity_interval = 0
+warm_up_steps = [0]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter = 1
+logging_iter = 1
+max_iter = 10
+num_epochs = 1
+steps_per_epoch = 10
+max_val_iter = 10
+run_validation = true
+validation_iter = 10
+validation_freq_in_epoch = 1
+run_validation_on_start = false
+
+[trainer.callbacks.compile_tokenizer]
+compile_after_iterations = 3
+enabled = false
+
+[trainer.callbacks.grad_clip]
+clip_norm = 1.0
+force_finite = false
+
+[trainer.callbacks.tao]
+enabled = true
+experiment_name = "Cosmos Framework AETC DAFT SFT"
+logging_interval = 1
+validation_heartbeat_interval = 1
+
+[checkpoint]
+keys_to_skip_loading = []
+load_path = "???"
+save_iter = 10
+save_freq_in_epoch = 1
+
+[dataloader_train]
+max_samples_per_batch = 1
+max_sequence_length = 40960

--- a/examples/toml/sft_config/wts_vlm.toml
+++ b/examples/toml/sft_config/wts_vlm.toml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# WTS video-QA SFT through the migrated Cosmos Framework VLM trainer.
+# Required environment:
+#   WTS_TRAIN_ANNOTATION, WTS_TRAIN_MEDIA
+#   WTS_VAL_ANNOTATION, WTS_VAL_MEDIA
+#   VLM_SAFETENSORS_PATH (Cosmos3-Nano converted to Qwen3-VL safetensors)
+# This checked-in recipe is a 10-step-per-epoch smoke run. Set
+# trainer.steps_per_epoch to the distributed update count for a production dataset.
+
+[job]
+task       = "vlm"
+experiment = "wts_vlm"
+project    = "cosmos3_reasoner"
+group      = "wts_sft"
+name       = "wts_vlm"
+wandb_mode = "disabled"
+
+[model]
+attn_implementation = "cosmos"
+precision = "bfloat16"
+
+[model.backbone]
+model_name = "${oc.env:VLM_SAFETENSORS_PATH}"
+safetensors_path = "${oc.env:VLM_SAFETENSORS_PATH}"
+
+[model.ema]
+enabled = false
+rate = 0.1
+iteration_shift = 0
+
+[model.parallelism]
+data_parallel_shard_degree = 4
+data_parallel_replicate_degree = 1
+context_parallel_shard_degree = 1
+cfg_parallel_shard_degree = 1
+
+[model.compile]
+enabled = false
+compile_dynamic = true
+
+[model.activation_checkpointing]
+mode = "full"
+save_ops_regex = ["fmha"]
+preserve_rng_state = true
+determinism_check = "default"
+
+[optimizer]
+betas = [0.9, 0.999]
+eps = 1.0e-8
+fused = true
+lr = 1.0e-4
+weight_decay = 0.01
+
+[scheduler]
+cycle_lengths = [20]
+f_max = [1.0]
+f_min = [0.0]
+f_start = [0.0]
+verbosity_interval = 0
+warm_up_steps = [0]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter = 1
+logging_iter = 1
+max_iter = 20
+num_epochs = 2
+steps_per_epoch = 10
+max_val_iter = 10
+run_validation = true
+validation_iter = 10
+validation_freq_in_epoch = 1
+run_validation_on_start = false
+
+[trainer.callbacks.compile_tokenizer]
+compile_after_iterations = 3
+enabled = false
+
+[trainer.callbacks.grad_clip]
+clip_norm = 1.0
+force_finite = false
+
+[trainer.callbacks.tao]
+enabled = true
+experiment_name = "Cosmos Framework WTS SFT"
+logging_interval = 1
+validation_heartbeat_interval = 1
+
+[checkpoint]
+keys_to_skip_loading = []
+load_path = "???"
+save_iter = 100
+save_freq_in_epoch = 2
+
+[dataloader_train]
+max_samples_per_batch = 1
+max_sequence_length = 81920

--- a/examples/toml/sft_config/wts_vlm_edge.toml
+++ b/examples/toml/sft_config/wts_vlm_edge.toml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# WTS video-QA SFT on the native Cosmos3-Edge reasoner checkpoint.
+# This checked-in recipe is a 10-step-per-epoch smoke run. Set
+# trainer.steps_per_epoch to the distributed update count for a production dataset.
+
+[job]
+task       = "vlm"
+experiment = "wts_vlm_edge"
+project    = "cosmos3_reasoner"
+group      = "wts_edge_sft"
+name       = "wts_vlm_edge"
+wandb_mode = "disabled"
+
+[model]
+attn_implementation = "flash_attention_2"
+precision = "bfloat16"
+
+[model.backbone]
+model_name = "${oc.env:VLM_SAFETENSORS_PATH}"
+safetensors_path = "${oc.env:VLM_SAFETENSORS_PATH}"
+
+[model.ema]
+enabled = false
+rate = 0.1
+iteration_shift = 0
+
+[model.parallelism]
+data_parallel_shard_degree = 4
+data_parallel_replicate_degree = 1
+context_parallel_shard_degree = 1
+cfg_parallel_shard_degree = 1
+
+[model.compile]
+enabled = false
+compile_dynamic = true
+
+[model.activation_checkpointing]
+mode = "full"
+save_ops_regex = ["fmha"]
+preserve_rng_state = true
+determinism_check = "default"
+
+[optimizer]
+betas = [0.9, 0.999]
+eps = 1.0e-8
+fused = true
+lr = 1.0e-4
+weight_decay = 0.01
+
+[scheduler]
+cycle_lengths = [20]
+f_max = [1.0]
+f_min = [0.0]
+f_start = [0.0]
+verbosity_interval = 0
+warm_up_steps = [0]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter = 1
+logging_iter = 1
+max_iter = 20
+num_epochs = 2
+steps_per_epoch = 10
+max_val_iter = 10
+run_validation = true
+validation_iter = 10
+validation_freq_in_epoch = 1
+run_validation_on_start = false
+
+[trainer.callbacks.compile_tokenizer]
+compile_after_iterations = 3
+enabled = false
+
+[trainer.callbacks.grad_clip]
+clip_norm = 1.0
+force_finite = false
+
+[trainer.callbacks.tao]
+enabled = true
+experiment_name = "Cosmos Framework WTS Edge SFT"
+logging_interval = 1
+validation_heartbeat_interval = 1
+
+[checkpoint]
+keys_to_skip_loading = []
+load_path = "???"
+save_iter = 100
+save_freq_in_epoch = 2
+
+[dataloader_train]
+max_samples_per_batch = 1
+max_sequence_length = 16000

--- a/uv.lock
+++ b/uv.lock
@@ -146,13 +146,6 @@ conflicts = [[
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },
 ], [
-    { package = "cosmos-framework", group = "cu128" },
-    { package = "cosmos-framework", group = "cu128-train" },
-    { package = "cosmos-framework", group = "cu130" },
-    { package = "cosmos-framework", group = "cu130-torch213-train" },
-    { package = "cosmos-framework", group = "cu130-train" },
-    { package = "cosmos-framework", group = "vllm" },
-], [
     { package = "cosmos-framework", group = "cu128-train" },
     { package = "cosmos-framework", group = "cu130" },
     { package = "cosmos-framework", group = "cu130-torch213" },
@@ -160,12 +153,19 @@ conflicts = [[
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },
 ], [
+    { package = "cosmos-framework", group = "cu128" },
     { package = "cosmos-framework", group = "cu128-train" },
     { package = "cosmos-framework", group = "cu130" },
     { package = "cosmos-framework", group = "cu130-torch213-train" },
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },
 ], [
+    { package = "cosmos-framework", group = "cu128" },
+    { package = "cosmos-framework", group = "cu128-train" },
+    { package = "cosmos-framework", group = "cu130-torch213-train" },
+    { package = "cosmos-framework", group = "cu130-train" },
+    { package = "cosmos-framework", group = "vllm" },
+], [
     { package = "cosmos-framework", group = "cu128-train" },
     { package = "cosmos-framework", group = "cu130-torch213" },
     { package = "cosmos-framework", group = "cu130-torch213-train" },
@@ -177,15 +177,15 @@ conflicts = [[
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },
 ], [
-    { package = "cosmos-framework", group = "cu128" },
     { package = "cosmos-framework", group = "cu128-train" },
-    { package = "cosmos-framework", group = "cu130-torch213" },
+    { package = "cosmos-framework", group = "cu130" },
     { package = "cosmos-framework", group = "cu130-torch213-train" },
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },
 ], [
     { package = "cosmos-framework", group = "cu128" },
     { package = "cosmos-framework", group = "cu128-train" },
+    { package = "cosmos-framework", group = "cu130-torch213" },
     { package = "cosmos-framework", group = "cu130-torch213-train" },
     { package = "cosmos-framework", group = "cu130-train" },
     { package = "cosmos-framework", group = "vllm" },


### PR DESCRIPTION
## Summary

- add TAO-compatible WTS supervised fine-tuning recipes for Cosmos Nano and Edge
- add TAO status reporting, epoch-based validation/checkpoint integration, and non-root container support
- add DAFT-backed AETC supervised fine-tuning configuration
- exclude Python bytecode from Docker build contexts

## Why

This brings the TAO training workflow from the Cosmos-RL integration into Cosmos Framework so fine-tuned Framework checkpoints can be trained and consumed by TAO actions without merging the public Cosmos-RL implementation into the runtime image.

## Impact

Users can launch WTS and AETC SFT through Cosmos Framework with TAO-compatible reporting and checkpoint behavior. The Docker image can run under non-root Pyxis and SLURM environments.

## Validation

- built the Cosmos Framework container image
- completed full WTS Nano and Edge training on SLURM
- completed full AETC Nano and Edge training on the parity dataset
- completed 367-sample AETC evaluations and compared Cosmos-RL and Framework BERTScore results