### PR TITLE
Upgrade pinned hf CLI to 1.26.0 for Xet-backed repos

### DIFF
--- a/cosmos_framework/utils/hf_cli/pyproject.toml
+++ b/cosmos_framework/utils/hf_cli/pyproject.toml
@@ -8,7 +8,7 @@ name = "imaginaire-hf-cli"
 version = "0.0.0"
 requires-python = ">=3.10"
 dependencies = [
-    "hf==1.25.1",
+    "hf==1.26.0",
 ]
 
 [tool.uv]

--- a/cosmos_framework/utils/hf_cli/uv.lock
+++ b/cosmos_framework/utils/hf_cli/uv.lock
@@ -87,13 +87,13 @@ wheels = [
 
 [[package]]
 name = "hf"
-version = "1.25.1"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/b5/e7122d22e13911155695539bd38dafb985354d268397bb47e625fd8ee8ba/hf-1.25.1-py3-none-any.whl", hash = "sha256:04850b825c8fc014bbec86570c4ca76a4dc7dcdb37b1af845577de3f757d5709", size = 2416, upload-time = "2026-07-27T09:24:10.463Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a2/96c8d9058397156c679fc8931dcab7c3622c37550002d1b7d456a2a15e70/hf-1.26.0-py3-none-any.whl", hash = "sha256:67459e96dc10053f3fbbd7604d1c46264850550b238b417106554597dbd084f0", size = 2417, upload-time = "2026-07-30T14:11:54.328Z" },
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.25.1"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -163,9 +163,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/50/db3771a6e4fad4bd28fb055d4363b51cb0ae98c1aa504b79d41fdcab5483/huggingface_hub-1.25.1.tar.gz", hash = "sha256:21129595ca7a753be479b319913e22cc8808361ac118bd76cc413db831b28a99", size = 928426, upload-time = "2026-07-27T09:24:10.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/21e816831c6d16f88a6c784974413fa0421ce8a5d04380c2666ed5b503e5/huggingface_hub-1.25.1-py3-none-any.whl", hash = "sha256:004d4e70350517e24c68a7dbb7dc5e40b2b6aefef8f94bf7a85f6f9835102ea5", size = 774909, upload-time = "2026-07-27T09:24:08.079Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
 ]
 
 [[package]]
@@ -186,7 +186,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "hf", specifier = "==1.25.1" }]
+requires-dist = [{ name = "hf", specifier = "==1.26.0" }]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
The locked hf 1.25.1 in `cosmos_framework/utils/hf_cli` fails on repositories migrated to Hugging Face Xet storage. Reproduced with the framework's own download path (`checkpoint_db._hf_download`) against `nvidia/Cosmos-Guardrail1`:

```
RuntimeError: Task error: Unable to parse string as hex hash value
```

The action-policy inference server hard-requires that download at startup, so serving is currently broken on a fresh machine.

**Change.** Bump the pin to `hf==1.26.0` and regenerate `uv.lock` with the documented procedure from the file header (`uv lock --upgrade-package hf`). Two files, no code change.

**Validation.** On a fresh 8xA100 instance, cleared the model from the HF cache and re-ran the framework's exact download command with the new lock: full 3.5 GB snapshot (102 files) downloaded clean and returned the snapshot path.

Found while validating #162 on rented hardware.