### PR TITLE
Make `wandb` and `lerobot` optional across default callbacks and datasets

### DIFF
--- a/cosmos_framework/callbacks/device_monitor.py
+++ b/cosmos_framework/callbacks/device_monitor.py
@@ -8,13 +8,17 @@ import pandas as pd
 import psutil
 import pynvml
 import torch
-import wandb
 
 from cosmos_framework.callbacks.every_n import EveryN
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import distributed, log
 from cosmos_framework.utils.easy_io import easy_io
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def log_prof_data(
@@ -49,7 +53,7 @@ def log_prof_data(
     df = pd.DataFrame(data, columns=columns)
     summary_df = pd.DataFrame({"Avg": avg_values, "Max": max_values, "Min": min_values})
 
-    if wandb.run:
+    if wandb and wandb.run:
         # Log the table
         table = wandb.Table(dataframe=df)
         wandb.log({"DeviceMonitor/prof_data": table}, step=iteration)
@@ -174,7 +178,7 @@ class DeviceMonitor(EveryN):
             log.info(f"{self.name} Stats:\n{summary_df.to_string()}")
             if self.log_memory_detail:
                 memory_stats = torch.cuda.memory_stats()
-                if wandb.run:
+                if wandb and wandb.run:
                     wandb_memory_info = {f"mem/{key}": memory_stats[key] for key in memory_stats.keys()}
                     wandb.log(wandb_memory_info, step=iteration)
                 if self.save_s3:

--- a/cosmos_framework/callbacks/dit_image_sample.py
+++ b/cosmos_framework/callbacks/dit_image_sample.py
@@ -10,12 +10,16 @@ from typing import Any
 
 import torch
 import torchvision
-import wandb
 
 from cosmos_framework.callbacks.every_n import EveryN
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import distributed
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 class DiTImageSampleCallback(EveryN):
@@ -75,7 +79,7 @@ class DiTImageSampleCallback(EveryN):
             if was_training:
                 model.train()
 
-        if self.rank != 0 or wandb.run is None or not generated_rows:
+        if self.rank != 0 or wandb is None or wandb.run is None or not generated_rows:
             return
 
         grid_images = torch.cat(generated_rows, dim=0)  # [R*B,3,H,W]

--- a/cosmos_framework/callbacks/every_n_draw_sample.py
+++ b/cosmos_framework/callbacks/every_n_draw_sample.py
@@ -14,9 +14,8 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import torchvision
 import torchvision.transforms.functional as torchvision_F
-import wandb
-from einops import rearrange
 
+from einops import rearrange
 from cosmos_framework.callbacks.every_n import EveryN
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import distributed, log, misc
@@ -24,6 +23,11 @@ from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.tools.visualize.video import save_img_or_video
 from cosmos_framework.model.generator.mot.context_parallel_utils import broadcast_context_parallel_object
 from cosmos_framework.utils.generator.data_utils import slice_data_batch
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 WandbImagePaths = str | dict[str, str]
 
@@ -361,7 +365,7 @@ def _add_wandb_image_paths(
     image_paths: WandbImagePaths | None,
     caption: str,
 ) -> None:
-    if image_paths is None:
+    if wandb is None or image_paths is None:
         return
     if isinstance(image_paths, dict):
         for key_suffix, image_path in image_paths.items():
@@ -751,7 +755,7 @@ class EveryNDrawSample(EveryN):
 
             log.debug("waiting for all ranks to finish", rank0_only=False)
             dist.barrier()
-        if wandb.run:
+        if wandb and wandb.run:
             sample_counter = getattr(trainer, "sample_counter", iteration)
             data_type = "image" if model.is_image_batch(data_batch) else "video"
             tag += f"_{data_type}"
@@ -1089,7 +1093,7 @@ class EveryNDrawSample(EveryN):
         file_base_fp = f"{base_fp_wo_ext}_resize.jpg"
         local_path = f"{self.local_dir}/{file_base_fp}"
 
-        if self.rank == 0 and wandb.run:
+        if self.rank == 0 and wandb and wandb.run:
             if is_single_frame:  # image case
                 to_show = rearrange(
                     to_show[:, :n_columns],

--- a/cosmos_framework/callbacks/expert_heatmap.py
+++ b/cosmos_framework/callbacks/expert_heatmap.py
@@ -3,7 +3,6 @@
 
 import matplotlib.pyplot as plt
 import torch
-import wandb
 from torch.distributed.tensor import DTensor, Partial
 
 from cosmos_framework.callbacks.every_n import EveryN
@@ -11,6 +10,11 @@ from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import distributed
 from cosmos_framework.model.generator.reasoner.qwen3_vl_moe.qwen3_vl_moe import Qwen3VLMoeTextSparseMoeBlock
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def compute_expert_heatmap(vfm: torch.nn.Module) -> dict[str, torch.Tensor]:
@@ -93,7 +97,7 @@ class ExpertHeatmap(EveryN):
     ) -> None:
         expert_heatmaps = compute_expert_heatmap(model.net)
 
-        if distributed.is_rank0() and wandb.run:
+        if distributed.is_rank0() and wandb and wandb.run:
             for tower, heatmap in expert_heatmaps.items():
                 fig, ax = plt.subplots()
                 im = ax.imshow(heatmap.cpu().numpy())

--- a/cosmos_framework/callbacks/grad_clip.py
+++ b/cosmos_framework/callbacks/grad_clip.py
@@ -5,11 +5,15 @@ import math
 from collections import defaultdict
 
 import torch
-import wandb
 from torch.distributed.tensor import DTensor
 
 from cosmos_framework.utils import log
 from cosmos_framework.utils.callback import Callback
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def _fused_nan_to_num(grads: list[torch.Tensor]) -> None:
@@ -323,5 +327,5 @@ class GradClip(Callback):
                     log_dict[key] = avg
                     if mesh_str == "global":
                         log.info(f"{key}: {avg:.5f} (iteration {iteration})", rank0_only=False)
-            if wandb.run:
+            if wandb and wandb.run:
                 wandb.log(log_dict, step=iteration)

--- a/cosmos_framework/callbacks/iter_speed.py
+++ b/cosmos_framework/callbacks/iter_speed.py
@@ -4,7 +4,6 @@
 import time
 
 import torch
-import wandb
 from torch import Tensor
 
 from cosmos_framework.callbacks.every_n import EveryN
@@ -13,6 +12,11 @@ from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import log
 from cosmos_framework.utils.distributed import rank0_only
 from cosmos_framework.utils.easy_io import easy_io
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 class IterSpeed(EveryN):
@@ -100,7 +104,7 @@ class IterSpeed(EveryN):
             if hasattr(model, "token_counter"):
                 per_sample_batch_counter["token_counter"] = model.token_counter
 
-        if wandb.run:
+        if wandb and wandb.run:
             sample_counter = getattr(trainer, "sample_counter", iteration)
             wandb.log(
                 {

--- a/cosmos_framework/callbacks/mfu.py
+++ b/cosmos_framework/callbacks/mfu.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 import torch
-import wandb
 
 from cosmos_framework.model.attention.utils import is_blackwell_dc
 from cosmos_framework.callbacks.every_n import EveryN
@@ -29,6 +28,11 @@ from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import log
 from cosmos_framework.utils.distributed import rank0_only
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 @dataclass
@@ -313,7 +317,7 @@ class MFUCallback(EveryN):
         log_info[f"mfu/{self.hardware_target.name}"] = mfu
 
         # W&B log
-        if wandb.run is not None:
+        if wandb and wandb.run is not None:
             wandb.log(log_info, step=iteration)
 
         # Reset accumulation window

--- a/cosmos_framework/callbacks/moe_specialization_callback.py
+++ b/cosmos_framework/callbacks/moe_specialization_callback.py
@@ -32,7 +32,6 @@ Buffer ownership
 """
 
 import torch
-import wandb
 from torch.distributed.tensor import DTensor, Partial
 
 from cosmos_framework.callbacks.every_n import EveryN
@@ -40,6 +39,11 @@ from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import distributed
 from cosmos_framework.model.generator.reasoner.qwen3_vl_moe.qwen3_vl_moe import Qwen3VLMoeTextSparseMoeBlock
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def _get_device_mesh(vfm: torch.nn.Module):
@@ -174,7 +178,7 @@ class MoESpecializationCallback(EveryN):
 
         coact_results = compute_moe_coactivation_metrics(vfm)
 
-        if not (distributed.is_rank0() and wandb.run):
+        if not (distributed.is_rank0() and wandb and wandb.run):
             return
 
         log_dict: dict[str, float] = {}

--- a/cosmos_framework/callbacks/moe_stability_callback.py
+++ b/cosmos_framework/callbacks/moe_stability_callback.py
@@ -136,7 +136,6 @@ DEAD_EXPERT_THRESHOLD_MULTIPLIER = 0.1
 ENTROPY_EPSILON = 1e-9
 
 import torch
-import wandb
 from torch.distributed.tensor import DTensor, Partial
 
 from cosmos_framework.callbacks.every_n import EveryN
@@ -144,6 +143,11 @@ from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import distributed
 from cosmos_framework.model.generator.reasoner.qwen3_vl_moe.qwen3_vl_moe import Qwen3VLMoeTextSparseMoeBlock
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def _effective_experts(
@@ -488,7 +492,7 @@ class MoEStabilityCallback(EveryN):
     ) -> None:
         metrics = compute_moe_stability_metrics(model.net)
 
-        if not (distributed.is_rank0() and wandb.run):
+        if not (distributed.is_rank0() and wandb and wandb.run):
             return
 
         if metrics and self._per_expert_params is None:

--- a/cosmos_framework/callbacks/norm_monitor.py
+++ b/cosmos_framework/callbacks/norm_monitor.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-import wandb
 from torch import nn
 from torch.distributed.tensor import DTensor
 
@@ -15,6 +14,11 @@ from cosmos_framework.utils import distributed, log, misc
 from cosmos_framework.utils.callback import Callback
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.data.generator.sequence_packing.runtime import get_gen_seq
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 try:
     from apex.contrib.layer_norm import FastLayerNorm
@@ -324,7 +328,7 @@ class NormMonitor(Callback):
                 stats[f"stats/act_grad_norm/{module_name}"] = l2_norm.item()
                 stats[f"stats/act_grad_max/{module_name}"] = stats_dict["max"].item()
 
-            if wandb.run is not None:
+            if wandb and wandb.run is not None:
                 if self.log_stat_wandb:
                     wandb.log({**stats, **important_info}, step=iteration)
                 else:

--- a/cosmos_framework/callbacks/ofu.py
+++ b/cosmos_framework/callbacks/ofu.py
@@ -21,7 +21,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import torch
-import wandb
 
 from cosmos_framework.model.attention.utils import is_blackwell_dc
 from cosmos_framework.callbacks.every_n import EveryN
@@ -29,6 +28,11 @@ from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.utils import log
 from cosmos_framework.utils.distributed import is_rank0, rank0_only
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 @dataclass
@@ -277,5 +281,5 @@ class OFUCallback(EveryN):
             "ofu/num_samples": float(len(samples)),
         }
 
-        if wandb.run is not None:
+        if wandb and wandb.run is not None:
             wandb.log(log_info, step=iteration)

--- a/cosmos_framework/callbacks/sequence_packing_padding.py
+++ b/cosmos_framework/callbacks/sequence_packing_padding.py
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: OpenMDW-1.1
 
 import torch
-import wandb
 
 from cosmos_framework.callbacks.every_n import EveryN
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.trainer import ImaginaireTrainer
 from cosmos_framework.data.generator.sequence_packing.runtime import get_padding_stats
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 class SequencePackingPadding(EveryN):
@@ -31,7 +35,7 @@ class SequencePackingPadding(EveryN):
         loss: torch.Tensor,
         iteration: int,
     ) -> None:
-        if wandb.run:
+        if wandb and wandb.run:
             padding_stats = get_padding_stats()
             log_dict = {
                 "SequencePackingPadding/max_causal_len_image_batch": padding_stats["MAX_CAUSAL_LEN_IMAGE_BATCH"],

--- a/cosmos_framework/callbacks/sigma_loss_analysis.py
+++ b/cosmos_framework/callbacks/sigma_loss_analysis.py
@@ -9,12 +9,16 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.distributed as dist
-import wandb
 
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import distributed, misc
 from cosmos_framework.utils.callback import Callback
 from cosmos_framework.utils.easy_io import easy_io
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 def _get_quantile_bins(n=10) -> np.ndarray:
@@ -107,8 +111,8 @@ class SigmaLossAnalysis(Callback):
         self,
         sigma_arr: torch.Tensor,
         loss_arr: torch.Tensor,  # [N]  # [N]
-    ) -> Optional[wandb.Image]:
-        if len(sigma_arr) == 0:
+    ) -> Optional[object]:
+        if len(sigma_arr) == 0 or wandb is None:
             return None
 
         # Convert to numpy for plotting
@@ -340,5 +344,5 @@ class SigmaLossAnalysis(Callback):
                 if len(self.video_cache.sigma_list) > 0:
                     info.update(self._gather_and_save(self.video_cache, iteration, "sigma_loss_video", log_viz=log_viz))
 
-                if distributed.is_rank0() and info and wandb.run:
+                if distributed.is_rank0() and info and wandb and wandb.run:
                     wandb.log(info, step=iteration)

--- a/cosmos_framework/callbacks/training_stats.py
+++ b/cosmos_framework/callbacks/training_stats.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 
 import torch
 import torch.distributed as dist
-import wandb
 
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import distributed
 from cosmos_framework.utils.callback import Callback
 from cosmos_framework.callbacks.wandb_log import _LossRecord
 from cosmos_framework.data.generator.action.domain_utils import EMBODIMENT_TO_DOMAIN_ID
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 # Build inverse mapping: domain_id -> embodiment_type. First occurrence wins when multiple embodiment names share the
 # same domain id.
@@ -275,10 +279,7 @@ class TrainingStatsCallback(Callback):
         embodiment_total, embodiment_counts = self._gather_global_embodiment_counts()
         per_embodiment_loss_dict = self._compute_per_embodiment_loss_stats(log_prefix="train")
 
-        if not distributed.is_rank0():
-            return
-
-        if wandb.run is None:
+        if not distributed.is_rank0() or wandb is None or wandb.run is None:
             return
 
         log_dict: dict[str, float] = {}

--- a/cosmos_framework/callbacks/wandb_log.py
+++ b/cosmos_framework/callbacks/wandb_log.py
@@ -9,12 +9,16 @@ from typing import Tuple
 import torch
 import torch.distributed as dist
 import torch.utils.data
-import wandb
 
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import distributed, log
 from cosmos_framework.utils.callback import Callback
 from cosmos_framework.utils.easy_io import easy_io
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 @dataclass
@@ -182,7 +186,7 @@ class WandbCallback(Callback):
 
             dist.all_reduce(self.unstable_count, op=dist.ReduceOp.SUM)
 
-            if distributed.is_rank0() and wandb.run is not None:
+            if distributed.is_rank0() and wandb and wandb.run is not None:
                 info = {}
                 info.update(
                     {

--- a/cosmos_framework/callbacks/wandb_log_eval.py
+++ b/cosmos_framework/callbacks/wandb_log_eval.py
@@ -9,12 +9,16 @@ from typing import Tuple
 import torch
 import torch.distributed as dist
 import torch.utils.data
-import wandb
 
 from cosmos_framework.model._base import ImaginaireModel
 from cosmos_framework.utils import distributed, log
 from cosmos_framework.utils.callback import Callback
 from cosmos_framework.utils.easy_io import easy_io
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 
 @dataclass
@@ -132,7 +136,7 @@ class WandbCallback(Callback):
                     f"s3://rundir/{self.name}/Val_Iter{iteration:09d}.json",
                 )
 
-            if wandb.run is not None:
+            if wandb and wandb.run is not None:
                 wandb.log(info, step=iteration)
 
         # reset unstable count

--- a/cosmos_framework/data/generator/action/datasets/cosmos3_action_lerobot.py
+++ b/cosmos_framework/data/generator/action/datasets/cosmos3_action_lerobot.py
@@ -29,8 +29,15 @@ from typing import Any, ClassVar
 import huggingface_hub.constants as _hf_const
 import numpy as np
 import torch
-from lerobot.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
 from torch.utils.data import Dataset
+
+try:
+    import lerobot as lerobot
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
+except ImportError:
+    lerobot = None
+    LeRobotDataset = object  # type: ignore
+    LeRobotDatasetMetadata = object  # type: ignore
 
 _hf_offline_applied = False
 
@@ -190,7 +197,7 @@ def _patch_decoder_cache(max_size: int = _LRU_VIDEO_CACHE_MAX_SIZE) -> None:
     """Replace the module-level ``_default_decoder_cache`` in LeRobot with an
     LRU-capped version to prevent unbounded memory growth in workers."""
     global _decoder_cache_patched
-    if _decoder_cache_patched:
+    if lerobot is None or _decoder_cache_patched:
         return
 
     import lerobot.datasets.video_utils as _vu
@@ -328,6 +335,11 @@ class BaseActionLeRobotDataset(Dataset):
         min_episode_length_frames: int | None = None,
     ) -> None:
         super().__init__()
+        if lerobot is None:
+            raise ImportError(
+                "LeRobot datasets require the `lerobot` package. "
+                "Please install `lerobot` to use this dataset."
+            )
         _ensure_hf_hub_offline()
         _patch_decoder_cache()
         self._memprofile = _memprofile_enabled()

--- a/cosmos_framework/data/generator/action/datasets/human_hand_pose_lerobot_dataset.py
+++ b/cosmos_framework/data/generator/action/datasets/human_hand_pose_lerobot_dataset.py
@@ -12,7 +12,6 @@ from typing import Any, Literal
 import numpy as np
 import pyarrow.parquet as pq
 import torch
-from lerobot.datasets.video_utils import decode_video_frames
 
 from cosmos_framework.data.generator.action.action_spec import ActionSpec, Pos, Rot, build_action_spec
 from cosmos_framework.data.generator.action.datasets.base_dataset import ActionBaseDataset
@@ -157,6 +156,8 @@ class HumanHandPoseLeRobotDataset(ActionBaseDataset):
         return result
 
     def _load_video(self, episode: dict[str, Any], rows: list[dict[str, Any]]) -> torch.Tensor:
+        from lerobot.datasets.video_utils import decode_video_frames
+
         timestamps = [float(row["timestamp"]) for row in rows]
         from_timestamp = float(episode.get(f"videos/{self._image_key}/from_timestamp", 0.0))
         return decode_video_frames(

--- a/cosmos_framework/utils/callback.py
+++ b/cosmos_framework/utils/callback.py
@@ -13,12 +13,15 @@ import torch
 import torch.distributed as dist
 import torch.utils.data
 import tqdm
-import wandb
 
 from cosmos_framework.utils.lazy_config import instantiate
 from cosmos_framework.utils import distributed, log, misc, wandb_util
 from cosmos_framework.utils.misc import get_local_tensor_if_DTensor
 
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore
 
 try:
     from megatron.core import parallel_state
@@ -446,7 +449,7 @@ class WandBCallback(Callback):
         grad_scaler: torch.amp.GradScaler,
         iteration: int = 0,
     ) -> None:  # Log the curent learning rate.
-        if iteration % self.config.trainer.logging_iter == 0 and distributed.is_rank0():
+        if iteration % self.config.trainer.logging_iter == 0 and distributed.is_rank0() and wandb and wandb.run:
             wandb.log({"optim/lr": scheduler.get_last_lr()[0]}, step=iteration)
             wandb.log({"optim/grad_scale": grad_scaler.get_scale()}, step=iteration)
 
@@ -468,7 +471,7 @@ class WandBCallback(Callback):
             dist.all_reduce(sample_size, op=dist.ReduceOp.SUM)
             avg_loss = loss_sum.item() / sample_size.item()
 
-            if distributed.is_rank0():
+            if distributed.is_rank0() and wandb and wandb.run:
                 wandb.log({f"timer/{key}": value for key, value in timer_results.items()}, step=iteration)
                 wandb.log({"train/loss": avg_loss}, step=iteration)
                 wandb.log({"iteration": iteration}, step=iteration)
@@ -506,10 +509,12 @@ class WandBCallback(Callback):
         # Log data/stats of validation set to W&B.
         if distributed.is_rank0():
             log.info(f"Validation loss (iteration {iteration}): {loss:4f}")
-            wandb.log({"val/loss": loss}, step=iteration)
+            if wandb and wandb.run:
+                wandb.log({"val/loss": loss}, step=iteration)
 
     def on_train_end(self, model: ImaginaireModel, iteration: int = 0) -> None:
-        wandb.finish()
+        if wandb and wandb.run:
+            wandb.finish()
 
 
 class LowPrecisionCallback(Callback):

--- a/cosmos_framework/utils/wandb_util.py
+++ b/cosmos_framework/utils/wandb_util.py
@@ -7,14 +7,18 @@ import os
 from typing import TYPE_CHECKING
 
 import attrs
-import wandb
-import wandb.util
 from omegaconf import DictConfig
 
 from cosmos_framework.utils.lazy_config.lazy import LazyConfig
 from cosmos_framework.utils import distributed, log, object_store
 from cosmos_framework.utils.easy_io import easy_io
 from cosmos_framework.utils.launch_defaults import get_wandb_entity, get_wandb_project
+
+try:
+    import wandb
+    import wandb.util
+except ImportError:
+    wandb = None  # type: ignore
 
 if TYPE_CHECKING:
     from cosmos_framework.utils.config import CheckpointConfig, Config, JobConfig
@@ -40,6 +44,8 @@ def init_wandb(config: Config, model: ImaginaireModel) -> None:
         config (Config): The config object for the Imaginaire codebase.
         model (ImaginaireModel): The PyTorch model.
     """
+    if wandb is None:
+        return
     if isinstance(config.job, DictConfig):
         from cosmos_framework.utils.config import JobConfig
 


### PR DESCRIPTION
## Why

- `wandb`: Due to security/CVE vulnerability concerns.
- `lerobot`: Avoids forcing heavy PyTorch version constraints and dependencies.

## Missing Dependency Test

```python
import sys, importlib.util

# 1. Simulate missing wandb & lerobot
sys.modules["wandb"] = None
sys.modules["wandb.util"] = None
sys.modules["lerobot"] = None
sys.modules["lerobot.datasets"] = None

from cosmos_framework.utils import wandb_util
from cosmos_framework.utils.callback import WandBCallback
from cosmos_framework.callbacks.device_monitor import DeviceMonitor
from cosmos_framework.callbacks.grad_clip import GradClip
from cosmos_framework.callbacks.iter_speed import IterSpeed
from cosmos_framework.callbacks.mfu import MFUCallback
from cosmos_framework.callbacks.norm_monitor import NormMonitor
from cosmos_framework.callbacks.ofu import OFUCallback
from cosmos_framework.callbacks.sequence_packing_padding import SequencePackingPadding
from cosmos_framework.callbacks.sigma_loss_analysis import SigmaLossAnalysis

# wandb disabled mode test without wandb installed (returns cleanly)
wandb_util.init_wandb(type("Cfg", (), {"job": type("J", (), {"wandb_mode": "disabled"})()})(), model=None)

# 2. lerobot dataset guard test (lerobot is None; raises controlled ImportError on init)
spec = importlib.util.spec_from_file_location("cosmos3_action_lerobot", "cosmos_framework/data/generator/action/datasets/cosmos3_action_lerobot.py")
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)

assert mod.lerobot is None
try:
    mod.BaseActionLeRobotDataset(
        fps=10, chunk_length=1, split_seed=0, split_val_ratio=0.1, split="train", mode="train", embodiment_type="droid_lerobot", viewpoint="ego_view"
    )
except ImportError as e:
    print(f"Controlled ImportError on instantiation: {e}")
```