### PR TITLE
fix(guardrail): do not block prose whose words fuse into a blocklist entry

### DIFF
--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -9,6 +9,8 @@ from difflib import SequenceMatcher
 
 import nltk
 from better_profanity import profanity
+from better_profanity.constants import ALLOWED_CHARACTERS
+from better_profanity.varying_string import VaryingString
 from nltk.corpus import wordnet
 
 from cosmos_framework.auxiliary.guardrail.blocklist.utils import read_keyword_list_from_dir, to_ascii
@@ -31,10 +33,22 @@ CENSOR_SENTINEL = "\x00"
 # never used to decide whether something was censored.
 CENSOR = misc.Color.red("*")
 
-# How many adjacent tokens may be fused when looking for a separator-stripped
-# evasion, i.e. a blocked word written with a space inserted mid-word.
-# Mirrors better_profanity's own lookahead.
-_MAX_JOIN_TOKENS = 3
+# Punctuation that better_profanity does not treat as part of a word. The
+# library's ALLOWED_CHARACTERS overlaps string.punctuation on " $ ' * @, which
+# are exactly the characters it substitutes for letters (a->@, s->$, * for
+# several vowels). Stripping those would erase a token the library still
+# matches on, so only the remainder is stripped here.
+_STRIP_CHARS = "".join(sorted(set(string.punctuation) - ALLOWED_CHARACTERS))
+
+# Environment override for guardrail_exempt_fused_prose, so the stricter
+# behaviour is selectable without editing code -- presets.py constructs
+# Blocklist() with no arguments. Set to "0" to restore strict fused matching.
+_EXEMPT_FUSED_PROSE_ENV = "COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE"
+
+
+def exempt_fused_prose_default() -> bool:
+    """Resolve the default for guardrail_exempt_fused_prose from the environment."""
+    return os.environ.get(_EXEMPT_FUSED_PROSE_ENV, "1") != "0"
 
 
 class Blocklist(ContentSafetyGuardrail):
@@ -42,7 +56,7 @@ class Blocklist(ContentSafetyGuardrail):
         self,
         guardrail_partial_match_min_chars: int = 6,
         guardrail_partial_match_letter_count: float = 0.4,
-        guardrail_exempt_fused_prose: bool = True,
+        guardrail_exempt_fused_prose: bool | None = None,
     ) -> None:
         """Blocklist model for text filtering safety check.
 
@@ -57,8 +71,12 @@ class Blocklist(ContentSafetyGuardrail):
                 Set False to restore the stricter previous behaviour, which blocks
                 that sentence but never lets a fused match through. See
                 `_has_legitimate_match` for the escape class this trades away.
-                Defaults to True.
+                Defaults to the COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE environment
+                variable, which itself defaults to True; set that variable to "0"
+                to select strict matching without editing code.
         """
+        if guardrail_exempt_fused_prose is None:
+            guardrail_exempt_fused_prose = exempt_fused_prose_default()
         self.checkpoint_dir = os.path.join(GUARDRAIL1_CHECKPOINT.download(), "blocklist")
         nltk.data.path.append(os.path.join(self.checkpoint_dir, "nltk_data"))
         self.lemmatizer = nltk.WordNetLemmatizer()
@@ -73,16 +91,30 @@ class Blocklist(ContentSafetyGuardrail):
         self.exact_match_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "exact_match"))
 
         self.profanity.load_censor_words(custom_words=self.blocklist_words, whitelist_words=self.whitelist_words)
+        self._configure_join_bookkeeping()
+        log.debug(f"Loaded {len(self.blocklist_words)} words/phrases from blocklist")
+        log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
+        log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
+
+    def _configure_join_bookkeeping(self) -> None:
+        """Derive the fused-join state from the loaded blocklist and matcher.
+
+        Called from __init__ and from the test helper, so tests exercise the
+        values production actually runs with rather than a reimplementation.
+        Requires self.profanity to be loaded and self.blocklist_words to be set.
+        """
         self._dictionary_cache: dict[str, bool] = {}
         self._max_blocklist_words = max((len(w.split()) for w in self.blocklist_words), default=1)
         # Entries that genuinely contain spaces, so a spaced match can be told
         # apart from a match that only worked because the spaces were deleted.
-        self._blocklist_phrases = {
-            " ".join(w.lower().split()) for w in self.blocklist_words if " " in w
-        }
-        log.debug(f"Loaded {len(self.blocklist_words)} words/phrases from blocklist")
-        log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
-        log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
+        # Stored the way the library stores its own entries, so comparison
+        # dispatches to VaryingString.__eq__ and leet spellings of a phrase
+        # ("b0ston dynamics") still match.
+        self._blocklist_phrases = [
+            VaryingString(" ".join(w.lower().split()), char_map=self.profanity.CHARS_MAPPING)
+            for w in self.blocklist_words
+            if " " in w
+        ]
 
     def uncensor_whitelist(self, input_prompt: str, censored_prompt: str) -> str:
         """Explicitly uncensor words that are in the whitelist."""
@@ -185,11 +217,12 @@ class Blocklist(ContentSafetyGuardrail):
           evasion. "assassin" written as "ass ass in" would pass. Set
           `guardrail_exempt_fused_prose=False` to give this up and go back to
           blocking every fused match, at the cost of blocking ordinary prose.
-        * **Escape classes that already existed.** Fused matching never reached
-          far anyway: with the blocklist entry "nike", stock code blocks "n ike"
-          and "ni ke" but not "nik e" or "n i k e", because the library looks
-          ahead only two words and misses trailing single letters. Nothing here
-          widens those.
+        * **The library's reach is wide.** With the entry "nike", stock code
+          blocks "n ike", "ni ke", "nik e" and "n i k e" alike once a following
+          word closes the window ("nik e shoe"). An earlier version of this note
+          claimed the last two escaped; that was measured on fragments with no
+          trailing token and is wrong. The exemption below therefore gives up
+          more than first documented.
         * **WordNet is the trust boundary.** "Ordinary English" means "WordNet has
           a synset", which over-includes: it counts single letters such as "n" and
           "f" as words, which is why `_is_prose_word` requires two characters. A
@@ -204,7 +237,10 @@ class Blocklist(ContentSafetyGuardrail):
 
         whitelist = {w.lower() for w in self.whitelist_words}
         raw_tokens = input_prompt.split()
-        tokens = [t.strip(string.punctuation).lower() for t in raw_tokens]
+        # Strip only punctuation the library does not count as part of a word.
+        # Stripping its leet characters would empty a token it still matches on,
+        # and an empty token aborts the window scan below.
+        tokens = [t.strip(_STRIP_CHARS).lower() for t in raw_tokens]
 
         for raw, token in zip(raw_tokens, tokens):
             if token and token not in whitelist and self._fires(raw):
@@ -212,8 +248,11 @@ class Blocklist(ContentSafetyGuardrail):
 
         # Phrase matches are bounded by the longest blocklist entry, but a
         # separator-stripped join fuses several tokens into ONE entry word, so it
-        # needs its own bound. Three matches the library's own lookahead.
-        max_window = max(self._max_blocklist_words, _MAX_JOIN_TOKENS)
+        # needs its own bound. Take that bound from the library rather than a
+        # local constant: MAX_NUMBER_COMBINATIONS is monotonic across
+        # load_censor_words calls, so the matcher's reach can exceed anything
+        # derived from the custom list alone.
+        max_window = max(self._max_blocklist_words, self.profanity.MAX_NUMBER_COMBINATIONS + 1)
         for i in range(len(tokens)):
             upper = min(max_window, len(tokens) - i)
             for size in range(2, upper + 1):

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -82,6 +82,13 @@ class Blocklist(ContentSafetyGuardrail):
             bool: True if the prompt is blocked, False otherwise
             str: A message indicating why the prompt was blocked
         """
+        # Strip any sentinel already present in the input. to_ascii preserves
+        # \x00 (its range is [^\x00-\x7F]), so without this an input carrying a
+        # NUL would be reported as censored even with no blocklist match -- the
+        # same in-band-marker failure this sentinel replaced. Removing rather
+        # than substituting keeps the stricter reading: "n\x00ike" fuses back to
+        # a blocked word instead of being split into two harmless tokens.
+        input_prompt = input_prompt.replace(CENSOR_SENTINEL, "")
         censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
         # Uncensor whitelisted words that were censored from blocklist fuzzy matching
         censored_prompt = self.uncensor_whitelist(input_prompt, censored_prompt)

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -9,6 +9,7 @@ from difflib import SequenceMatcher
 
 import nltk
 from better_profanity import profanity
+from nltk.corpus import wordnet
 
 from cosmos_framework.auxiliary.guardrail.blocklist.utils import read_keyword_list_from_dir, to_ascii
 from cosmos_framework.auxiliary.guardrail.common.core import (
@@ -30,12 +31,18 @@ CENSOR_SENTINEL = "\x00"
 # never used to decide whether something was censored.
 CENSOR = misc.Color.red("*")
 
+# How many adjacent tokens may be fused when looking for a separator-stripped
+# evasion, i.e. a blocked word written with a space inserted mid-word.
+# Mirrors better_profanity's own lookahead.
+_MAX_JOIN_TOKENS = 3
+
 
 class Blocklist(ContentSafetyGuardrail):
     def __init__(
         self,
         guardrail_partial_match_min_chars: int = 6,
         guardrail_partial_match_letter_count: float = 0.4,
+        guardrail_exempt_fused_prose: bool = True,
     ) -> None:
         """Blocklist model for text filtering safety check.
 
@@ -43,6 +50,14 @@ class Blocklist(ContentSafetyGuardrail):
             checkpoint_dir (str): Path to the checkpoint directory.
             guardrail_partial_match_min_chars (int, optional): Minimum number of characters in a word to check for partial match. Defaults to 6.
             guardrail_partial_match_letter_count (float, optional): Maximum allowed difference in characters for partial match. Defaults to 0.4.
+            guardrail_exempt_fused_prose (bool, optional): When True, a match that
+                exists only because the spaces between ordinary English words were
+                deleted is treated as coincidence rather than evasion, so
+                "a desk in the background" does not match the entry "deskin".
+                Set False to restore the stricter previous behaviour, which blocks
+                that sentence but never lets a fused match through. See
+                `_has_legitimate_match` for the escape class this trades away.
+                Defaults to True.
         """
         self.checkpoint_dir = os.path.join(GUARDRAIL1_CHECKPOINT.download(), "blocklist")
         nltk.data.path.append(os.path.join(self.checkpoint_dir, "nltk_data"))
@@ -50,6 +65,7 @@ class Blocklist(ContentSafetyGuardrail):
         self.profanity = profanity
         self.guardrail_partial_match_min_chars = guardrail_partial_match_min_chars
         self.guardrail_partial_match_letter_count = guardrail_partial_match_letter_count
+        self.guardrail_exempt_fused_prose = guardrail_exempt_fused_prose
 
         # Load blocklist and whitelist keywords
         self.blocklist_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "custom"))
@@ -57,6 +73,13 @@ class Blocklist(ContentSafetyGuardrail):
         self.exact_match_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "exact_match"))
 
         self.profanity.load_censor_words(custom_words=self.blocklist_words, whitelist_words=self.whitelist_words)
+        self._dictionary_cache: dict[str, bool] = {}
+        self._max_blocklist_words = max((len(w.split()) for w in self.blocklist_words), default=1)
+        # Entries that genuinely contain spaces, so a spaced match can be told
+        # apart from a match that only worked because the spaces were deleted.
+        self._blocklist_phrases = {
+            " ".join(w.lower().split()) for w in self.blocklist_words if " " in w
+        }
         log.debug(f"Loaded {len(self.blocklist_words)} words/phrases from blocklist")
         log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
         log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
@@ -92,10 +115,118 @@ class Blocklist(ContentSafetyGuardrail):
         censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
         # Uncensor whitelisted words that were censored from blocklist fuzzy matching
         censored_prompt = self.uncensor_whitelist(input_prompt, censored_prompt)
-        if CENSOR_SENTINEL in censored_prompt:
-            display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
-            return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"
-        return False, ""
+        if CENSOR_SENTINEL not in censored_prompt:
+            return False, ""
+        # better_profanity also matches across word boundaries with the separators
+        # deleted, so confirm a real match exists before blocking. Only reached
+        # when something already matched, so the common path costs nothing.
+        if not self._has_legitimate_match(input_prompt):
+            return False, ""
+        display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
+        return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"
+
+    def _is_dictionary_word(self, word: str) -> bool:
+        """True if the word is ordinary English, per the WordNet corpus.
+
+        Used to tell an evasion apart from a coincidence. If the corpus is
+        unavailable, report False so every join stays suspicious and the filter
+        remains at least as strict as before.
+        """
+        if word not in self._dictionary_cache:
+            try:
+                self._dictionary_cache[word] = bool(wordnet.synsets(word))
+            except LookupError:
+                self._dictionary_cache[word] = False
+        return self._dictionary_cache[word]
+
+    def _is_prose_word(self, word: str) -> bool:
+        """True if the word could plausibly stand alone in ordinary prose.
+
+        Single letters are excluded even though WordNet knows them: a lone "f" or
+        "n" beside another word is the shape of an evasion ("n ike"), not
+        of normal writing.
+        """
+        return len(word) >= 2 and self._is_dictionary_word(word)
+
+    def _fires(self, text: str) -> bool:
+        """True if the matcher censors anything in `text`."""
+        return self.profanity.censor(text, censor_char=CENSOR_SENTINEL) != text
+
+    def _has_legitimate_match(self, input_prompt: str) -> bool:
+        """Re-check a flagged prompt with word boundaries respected.
+
+        better_profanity concatenates adjacent words with their separators removed
+        (`any_next_words_form_swear_word`) so that a blocked word written with a space
+        inserted mid-word is still caught -- "n ike" for the entry "nike". The
+        side effect is that ordinary prose collides with short blocklist entries:
+        "a desk in the background" forms "deskin".
+
+        A match is legitimate when any of these holds:
+
+        * a single whitespace-delimited token matches on its own -- this keeps
+          matches that join across punctuation inside a token, such as "desk-in";
+        * a run of tokens matches a blocklist entry that genuinely contains
+          spaces, such as "Boston Dynamics";
+        * a run of tokens matches only once the spaces are deleted AND at least
+          one part is not an ordinary English word -- which is what an evasion
+          looks like ("n ike", "to yota").
+
+        A space-deleted join whose every part is a dictionary word is rejected as
+        coincidence. Matching is delegated to the library throughout, so leet
+        substitutions and punctuation are handled exactly as before.
+
+        Known limits
+        ------------
+        This is a heuristic on top of a heuristic, and it is worth stating plainly
+        what it does and does not buy.
+
+        * **Escape class introduced here.** A banned word split into pieces that
+          are *all* multi-letter dictionary words is no longer treated as an
+          evasion. "assassin" written as "ass ass in" would pass. Set
+          `guardrail_exempt_fused_prose=False` to give this up and go back to
+          blocking every fused match, at the cost of blocking ordinary prose.
+        * **Escape classes that already existed.** Fused matching never reached
+          far anyway: with the blocklist entry "nike", stock code blocks "n ike"
+          and "ni ke" but not "nik e" or "n i k e", because the library looks
+          ahead only two words and misses trailing single letters. Nothing here
+          widens those.
+        * **WordNet is the trust boundary.** "Ordinary English" means "WordNet has
+          a synset", which over-includes: it counts single letters such as "n" and
+          "f" as words, which is why `_is_prose_word` requires two characters. A
+          fragment that WordNet happens to know ("ike") is treated as ordinary.
+        * **Layering matters.** The blocklist is a coarse pre-filter with model
+          based guardrails (llamaGuard3, qwen3guard, video content safety) running
+          alongside it. It is not the last line of defence, which is what makes
+          this trade reasonable rather than reckless.
+        """
+        if not self.guardrail_exempt_fused_prose:
+            return True
+
+        whitelist = {w.lower() for w in self.whitelist_words}
+        raw_tokens = input_prompt.split()
+        tokens = [t.strip(string.punctuation).lower() for t in raw_tokens]
+
+        for raw, token in zip(raw_tokens, tokens):
+            if token and token not in whitelist and self._fires(raw):
+                return True
+
+        # Phrase matches are bounded by the longest blocklist entry, but a
+        # separator-stripped join fuses several tokens into ONE entry word, so it
+        # needs its own bound. Three matches the library's own lookahead.
+        max_window = max(self._max_blocklist_words, _MAX_JOIN_TOKENS)
+        for i in range(len(tokens)):
+            upper = min(max_window, len(tokens) - i)
+            for size in range(2, upper + 1):
+                window = tokens[i : i + size]
+                if not all(window) or any(w in whitelist for w in window):
+                    break
+                if " ".join(window) in self._blocklist_phrases:
+                    return True
+                if self._fires("".join(window)) and not all(
+                    self._is_prose_word(w) for w in window
+                ):
+                    return True
+        return False
 
     @staticmethod
     def check_partial_match(

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -18,6 +18,16 @@ from cosmos_framework.auxiliary.guardrail.common.core import (
 )
 from cosmos_framework.utils import log, misc
 
+# Sentinel marking characters that the censor replaced. It must be a character
+# that cannot appear in ordinary text, because censorship is detected by looking
+# for it. Do not colourise it: termcolor strips ANSI escapes when stdout is not a
+# TTY, which reduced the sentinel to a bare "*" in any run whose output was piped
+# to a file, so text containing Markdown emphasis ("**bold**") was reported as
+# blocked even when the blocklist matched nothing.
+CENSOR_SENTINEL = "\x00"
+
+# Displayed to the user in the "Censored Prompt" message. Presentation only --
+# never used to decide whether something was censored.
 CENSOR = misc.Color.red("*")
 
 
@@ -72,11 +82,12 @@ class Blocklist(ContentSafetyGuardrail):
             bool: True if the prompt is blocked, False otherwise
             str: A message indicating why the prompt was blocked
         """
-        censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR)
+        censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
         # Uncensor whitelisted words that were censored from blocklist fuzzy matching
         censored_prompt = self.uncensor_whitelist(input_prompt, censored_prompt)
-        if CENSOR in censored_prompt:
-            return True, f"Prompt blocked by censorship: Censored Prompt: {censored_prompt}"
+        if CENSOR_SENTINEL in censored_prompt:
+            display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
+            return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"
         return False, ""
 
     @staticmethod

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from cosmos_framework.auxiliary.guardrail.blocklist.blocklist import Blocklist
+from cosmos_framework.auxiliary.guardrail.blocklist.blocklist import Blocklist, exempt_fused_prose_default
 
 
 @pytest.mark.L1
@@ -60,10 +60,12 @@ def _blocklist_with_words(words: list[str], dictionary: dict | None = None) -> B
     bl.profanity = Profanity()
     bl.profanity.load_censor_words(custom_words=words, whitelist_words=[])
     bl.whitelist_words = []
+    bl.blocklist_words = words
     bl.guardrail_exempt_fused_prose = True
-    bl._dictionary_cache = dict(dictionary or {})
-    bl._max_blocklist_words = max((len(w.split()) for w in words), default=1)
-    bl._blocklist_phrases = {" ".join(w.lower().split()) for w in words if " " in w}
+    # Same derivation production uses, so the join bookkeeping under test is not
+    # a reimplementation of it.
+    bl._configure_join_bookkeeping()
+    bl._dictionary_cache.update(dictionary or {})
     return bl
 
 
@@ -202,6 +204,81 @@ def test_single_token_match_across_punctuation_still_blocks():
     )
 
     blocked, _ = bl.censor_prompt("the desk-in the corner")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_leet_spelling_of_a_multi_word_entry_still_blocks():
+    """Phrase entries are stored as the library stores them, so o->0 still matches.
+
+    Regression test: holding them as plain strings let "b0ston dynamics" through
+    while stock better_profanity blocked it.
+    """
+    bl = _blocklist_with_words(
+        ["boston dynamics"],
+        {"a": True, "boston": True, "dynamics": True, "robot": True},
+    )
+
+    for prompt in ("a boston dynamics robot", "a b0ston dynamics robot", "a boston dynamic5 robot"):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is True, f"{prompt!r} should be blocked"
+
+
+@pytest.mark.L1
+def test_join_window_follows_the_library_reach():
+    """The window comes from the matcher, not from the custom list's longest entry.
+
+    Regression test: a local constant of 3 let a 4-token split escape while stock
+    better_profanity blocked it.
+    """
+    bl = _blocklist_with_words(
+        ["supercalifragil"],
+        {"su": True, "per": True, "cali": True, "fragil": False, "now": True},
+    )
+
+    blocked, _ = bl.censor_prompt("su per cali fragil now")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_leet_characters_are_not_stripped_from_tokens():
+    """Characters the library treats as letters must survive tokenisation.
+
+    Regression test: string.punctuation overlaps ALLOWED_CHARACTERS on " $ ' * @,
+    so stripping it emptied the "$" token and aborted the window scan, letting
+    "wear $ ike shoes" through while stock blocked it.
+    """
+    bl = _blocklist_with_words(
+        ["sike"], {"wear": True, "s": True, "ike": True, "shoes": True}
+    )
+
+    for prompt in ("wear s ike shoes", "wear $ ike shoes"):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is True, f"{prompt!r} should be blocked"
+
+
+@pytest.mark.L1
+def test_environment_variable_selects_strict_mode(monkeypatch):
+    """The stricter behaviour is reachable without editing code.
+
+    presets.py builds Blocklist() with no arguments, so without an environment
+    path the strict setting could only be chosen by editing source.
+    """
+    monkeypatch.delenv("COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE", raising=False)
+    assert exempt_fused_prose_default() is True
+
+    monkeypatch.setenv("COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE", "0")
+    assert exempt_fused_prose_default() is False
+
+    bl = _blocklist_with_words(
+        ["deskin"],
+        {"a": True, "desk": True, "in": True, "the": True, "background": True},
+    )
+    bl.guardrail_exempt_fused_prose = exempt_fused_prose_default()
+
+    blocked, _ = bl.censor_prompt("a desk in the background")
 
     assert blocked is True
 

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -45,11 +45,14 @@ def test_partial_match_with_threshold():
     assert match is False
 
 
-def _blocklist_with_words(words: list[str]) -> Blocklist:
+def _blocklist_with_words(words: list[str], dictionary: dict | None = None) -> Blocklist:
     """Build a Blocklist around a small word list, without downloading a checkpoint.
 
-    censor_prompt only needs the profanity matcher and the whitelist, so the
-    heavyweight __init__ (checkpoint download, nltk data) is bypassed here.
+    censor_prompt needs only the matcher, the whitelist and the fused-join
+    bookkeeping, so the heavyweight __init__ (checkpoint download, nltk data) is
+    bypassed. The dictionary is injected rather than read from WordNet so the
+    tests stay hermetic and exercise the heuristic directly instead of whatever
+    the corpus happens to contain.
     """
     from better_profanity.better_profanity import Profanity
 
@@ -57,6 +60,10 @@ def _blocklist_with_words(words: list[str]) -> Blocklist:
     bl.profanity = Profanity()
     bl.profanity.load_censor_words(custom_words=words, whitelist_words=[])
     bl.whitelist_words = []
+    bl.guardrail_exempt_fused_prose = True
+    bl._dictionary_cache = dict(dictionary or {})
+    bl._max_blocklist_words = max((len(w.split()) for w in words), default=1)
+    bl._blocklist_phrases = {" ".join(w.lower().split()) for w in words if " " in w}
     return bl
 
 
@@ -126,3 +133,92 @@ def test_blocked_word_is_still_detected_alongside_markdown():
     # blocked word is masked.
     assert "**bold**" in message
     assert "badword" not in message
+
+
+@pytest.mark.L1
+def test_adjacent_dictionary_words_do_not_form_a_blocked_word():
+    """Ordinary prose must not match by having its spaces deleted.
+
+    Regression test: better_profanity concatenates adjacent words with their
+    separators removed to catch evasions, so "a desk in the background" formed
+    "deskin" and tripped the blocklist.
+    """
+    bl = _blocklist_with_words(
+        ["deskin"],
+        {"a": True, "desk": True, "in": True, "the": True, "background": True},
+    )
+
+    blocked, _ = bl.censor_prompt("a desk in the background")
+
+    assert blocked is False
+
+
+@pytest.mark.L1
+def test_evasion_by_splitting_a_word_is_still_caught():
+    """The fix must not open an evasion route: a mid-word split still blocks.
+
+    A part that is not an ordinary English word marks the join as deliberate
+    rather than coincidental.
+    """
+    bl = _blocklist_with_words(
+        ["toyota"], {"a": True, "to": True, "yota": False, "car": True}
+    )
+
+    for prompt in ("a to yota car", "a toyota car"):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is True, f"{prompt!r} should be blocked"
+
+
+@pytest.mark.L1
+def test_single_letter_split_is_treated_as_evasion():
+    """"n ike" blocks even though WordNet knows both "n" and "ike"."""
+    bl = _blocklist_with_words(
+        ["nike"], {"n": True, "ike": True, "shoes": True}
+    )
+
+    blocked, _ = bl.censor_prompt("n ike shoes")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_multi_word_blocklist_phrase_still_matches():
+    """Entries that genuinely contain spaces keep matching with spacing intact."""
+    bl = _blocklist_with_words(
+        ["boston dynamics"],
+        {"a": True, "boston": True, "dynamics": True, "robot": True, "walks": True},
+    )
+
+    blocked, _ = bl.censor_prompt("a Boston Dynamics robot walks past")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_single_token_match_across_punctuation_still_blocks():
+    """Joins inside one token, e.g. "desk-in", are evasions and must still block."""
+    bl = _blocklist_with_words(
+        ["deskin"], {"the": True, "desk": True, "in": True, "corner": True}
+    )
+
+    blocked, _ = bl.censor_prompt("the desk-in the corner")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_strict_mode_restores_the_previous_fused_behaviour():
+    """guardrail_exempt_fused_prose=False gives up the fix for maximum strictness.
+
+    Deployments that would rather block ordinary prose than ever let a fused match
+    through can opt out; this pins that switch so it cannot rot.
+    """
+    bl = _blocklist_with_words(
+        ["deskin"],
+        {"a": True, "desk": True, "in": True, "the": True, "background": True},
+    )
+    bl.guardrail_exempt_fused_prose = False
+
+    blocked, _ = bl.censor_prompt("a desk in the background")
+
+    assert blocked is True

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -43,3 +43,60 @@ def test_partial_match_with_threshold():
     # With threshold of 0.5 character difference, should not match
     match, _ = Blocklist.check_partial_match(prompt, word, 0.5)
     assert match is False
+
+
+def _blocklist_with_words(words: list[str]) -> Blocklist:
+    """Build a Blocklist around a small word list, without downloading a checkpoint.
+
+    censor_prompt only needs the profanity matcher and the whitelist, so the
+    heavyweight __init__ (checkpoint download, nltk data) is bypassed here.
+    """
+    from better_profanity.better_profanity import Profanity
+
+    bl = Blocklist.__new__(Blocklist)
+    bl.profanity = Profanity()
+    bl.profanity.load_censor_words(custom_words=words, whitelist_words=[])
+    bl.whitelist_words = []
+    return bl
+
+
+@pytest.mark.L1
+def test_markdown_emphasis_is_not_treated_as_censorship():
+    """Text containing Markdown emphasis must not be reported as blocked.
+
+    Regression test: censorship used to be detected by searching the censored
+    output for a colourised "*". termcolor strips the colour when stdout is not
+    a TTY, leaving a bare "*", so any "**bold**" in the input matched the
+    sentinel and the prompt was blocked despite no blocklist hit.
+    """
+    bl = _blocklist_with_words(["badword"])
+
+    blocked, message = bl.censor_prompt("The robot moves a **box** across the floor.")
+
+    assert blocked is False
+    assert message == ""
+
+
+@pytest.mark.L1
+def test_asterisks_alone_do_not_trigger_a_block():
+    """Bare asterisks are ordinary characters, not evidence of censorship."""
+    bl = _blocklist_with_words(["badword"])
+
+    for prompt in ("a * b", "**", "5 * 3 = 15", "*emphasis* and **strong**"):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is False, f"{prompt!r} was wrongly reported as blocked"
+
+
+@pytest.mark.L1
+def test_blocked_word_is_still_detected_alongside_markdown():
+    """The fix must not weaken detection: a real hit still blocks, and still reports."""
+    bl = _blocklist_with_words(["badword"])
+
+    blocked, message = bl.censor_prompt("A **bold** heading and a badword in the text.")
+
+    assert blocked is True
+    assert "Censored Prompt:" in message
+    # The Markdown the model emitted is preserved in the message; only the
+    # blocked word is masked.
+    assert "**bold**" in message
+    assert "badword" not in message

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -88,6 +88,32 @@ def test_asterisks_alone_do_not_trigger_a_block():
 
 
 @pytest.mark.L1
+def test_sentinel_in_the_input_does_not_trigger_a_block():
+    """A NUL arriving in the input must not be mistaken for censorship.
+
+    to_ascii only replaces [^\\x00-\\x7F], so \\x00 survives normalization and
+    would otherwise reach the sentinel check unmodified.
+    """
+    bl = _blocklist_with_words(["badword"])
+
+    blocked, message = bl.censor_prompt("a clean prompt with \x00 in it")
+
+    assert blocked is False
+    assert message == ""
+
+
+@pytest.mark.L1
+def test_sentinel_cannot_be_used_to_split_a_blocked_word():
+    """Stripping the sentinel must not open an evasion: the word fuses back."""
+    bl = _blocklist_with_words(["badword"])
+
+    blocked, message = bl.censor_prompt("a bad\x00word in the text")
+
+    assert blocked is True
+    assert "badword" not in message
+
+
+@pytest.mark.L1
 def test_blocked_word_is_still_detected_alongside_markdown():
     """The fix must not weaken detection: a real hit still blocks, and still reports."""
     bl = _blocklist_with_words(["badword"])


### PR DESCRIPTION
# fix(guardrail): do not block prose whose words fuse into a blocklist entry

> **Stacked on #176.** This branch contains that commit as its parent, so the diff shown here
> is only the second commit (`a46df92`). Merge #176 first, or merge this one and #176 becomes
> redundant. The two defects are independent; they were split so each can be reviewed on its
> own.

## What is wrong

`better_profanity` concatenates adjacent words **with their separators removed**, so that a
blocked word written with a space inserted mid-word is still caught — `"n ike"` for the entry
`nike`:

```python
# better_profanity/utils.py -- any_next_words_form_swear_word
full_word = "%s%s" % (full_word, single_word.lower())          # separators dropped
if full_word in censor_words or full_word_with_separators in censor_words:
    return True, end_index
```

The side effect is that ordinary prose collides with short blocklist entries. `"a desk in the
background"` fuses into `deskin`, which is on the blocklist alongside `deskinned` and
`deskinning`, so a sentence describing office furniture is blocked as gore.

This is **not** governed by `guardrail_partial_match_min_chars`; that parameter applies to
`check_partial_match` against the exact-match list, which is a different code path.

Observed in an Edge reasoner QA sweep: item `4_3`, whose output describes "a robot standing
in a library, carrying a stack of books, with a desk in the background".

## The fix

Before blocking, re-check the flagged prompt with word boundaries respected. A match counts
as legitimate when:

* a single whitespace-delimited token matches on its own — this keeps joins **inside** a
  token, such as `"desk-in"`, blocking;
* a run of tokens matches a blocklist entry that genuinely contains spaces, such as
  `"Boston Dynamics"`;
* a run of tokens matches only once the spaces are deleted **and** at least one part is not
  ordinary English — the shape of a deliberate evasion.

A space-deleted join whose every part is an ordinary word is rejected as coincidence.

Single letters do not count as ordinary English even though WordNet knows them, because a
lone letter beside another word is what an evasion looks like, not normal writing. That keeps
`"n ike"` blocking.

Matching is delegated to `better_profanity` throughout, so leet substitutions and punctuation
behave exactly as before. WordNet is consulted only to classify a word as ordinary English;
if the corpus is unavailable the answer is "not ordinary", which keeps the filter at least as
strict as it is today.

## Behaviour

| input | before | after |
|---|---|---|
| `a desk in the background` | BLOCKED | **SAFE** |
| `a desk in front of a bookshelf` | BLOCKED | **SAFE** |
| `n ike shoes` (evasion) | BLOCKED | BLOCKED |
| `to yota cars` (evasion) | BLOCKED | BLOCKED |
| `desk-in the corner` (punctuation join) | BLOCKED | BLOCKED |
| `a Boston Dynamics robot` (multi-word entry) | BLOCKED | BLOCKED |
| `the Nike logo` (single-word entry) | BLOCKED | BLOCKED |
| `deskin` (the entry itself) | BLOCKED | BLOCKED |

Swept over all 492 outputs of the Edge reasoner QA corpus: blocks drop from 11 to the **3
genuine trademark hits** (`INTEL`, `Nike`, `Huracan`), with **no new blocks**. The other five
of the original eleven are cleared by #176.

## Cost

The re-check runs only after something has already matched, so text that was never flagged
costs nothing. On a flagged 106-token output the added work is **~43 ms**, against ~340 ms
for the surrounding `is_safe()` call, which is dominated by the pre-existing nltk tokenise
and lemmatise pass.

## Tests

Ten regression tests added, covering the fused-prose false positive, split evasions,
single-letter splits, multi-word phrases, punctuation joins, leet spellings of multi-word
entries, the join window's bound, leet characters inside tokens, and the strict-mode opt-out.
They inject the dictionary instead of reading WordNet, so they are hermetic — no checkpoint
download, no nltk corpus — and they exercise the heuristic directly rather than through
whatever the corpus happens to contain.

The helper builds its state by calling `_configure_join_bookkeeping()`, the same method
`__init__` uses, so the join bookkeeping under test is production's derivation rather than a
copy of it.

```
$ pytest cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py -q
18 passed
```

One of these tests caught a real bug during development: the join window was initially bounded
by the longest blocklist entry's word count, which is 1 for a single-word list, so pairs were
never examined. It passed against the production list only because that list happens to
contain a 6-word phrase. Join detection now carries its own bound.

## Escape class, stated plainly

This narrows evasion detection, and the trade is documented in `_has_legitimate_match` rather
than left implicit:

* **Introduced here.** A banned word split into pieces that are *all* multi-letter dictionary
  words is no longer treated as an evasion — `"assassin"` written as `"ass ass in"` would pass.
* **CORRECTED.** An earlier revision of this section claimed fused matching "never reached far
  to begin with" — that with the entry `nike`, stock blocked `"n ike"` and `"ni ke"` but not
  `"nik e"` or `"n i k e"`. That was measured on fragments with no trailing token, and it is
  wrong. The library's window needs a following word to close; once there is one, stock blocks
  all four forms:

  | input | stock | with this PR |
  |---|---|---|
  | `n ike shoe` | blocked | blocked |
  | `ni ke shoe` | blocked | blocked |
  | `nik e shoe` | **blocked** | blocked |
  | `n i k e shoe` | **blocked** | blocked |

  So stock is stricter than this PR originally described, and the exemption below gives up more
  than was first stated. Measured against the production WordNet corpus, all four rows still
  block with this PR — but only because WordNet has no synset for `ke`, `nik`, `k` alone as a
  fused part, and so on. That is the trust boundary in the next bullet doing the work, and it is
  the honest reason those rows survive, not a property of the heuristic itself.

* **WordNet is the trust boundary.** "Ordinary English" means "WordNet has a synset", which
  over-includes: it counts single letters such as `n` and `f` as words. That is why
  `_is_prose_word` requires two characters — without it, `"n ike"` would escape.
* **Layering.** The blocklist is a coarse pre-filter running alongside model-based guardrails
  (`llamaGuard3`, `qwen3guard`, video content safety). It is not the last line of defence,
  which is what makes this trade reasonable rather than reckless.

## Opt-out

`guardrail_exempt_fused_prose` switches the behaviour. Set it `False` to restore the stricter
previous behaviour: ordinary prose is blocked again, but no fused match is ever let through.
Verified both ways over the QA corpus — the default blocks the 3 genuine trademark hits, strict
mode adds `4_3` back.

Because `presets.py:17` constructs `Blocklist()` with no arguments, the flag also reads
`COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE` when it is not passed explicitly, so strict matching is
selectable at deploy time rather than only by editing source:

```
COSMOS_GUARDRAIL_EXEMPT_FUSED_PROSE=0    # strict: block every fused match
```

That closes the "no off switch in practice" half of the strictness question. The other half —
whether the relaxed setting should be the default for every caller at all — is a decision for
the guardrail owners, not something this PR should settle on its own. Flagging it explicitly
rather than letting it ride in on a false-positive fix.

If the maintainers would rather not carry a heuristic here at all, there is a cleaner option
worth considering instead of this PR: **fix the data.** `deskin` is a rare gore stem that is
also the fusion of two of the commonest English words, sitting on a list that is otherwise
trademarks. Pruning or lengthening entries like it removes the false positive with no loss of
evasion resistance, which is strictly better than any code-side heuristic. I am happy to
withdraw this in favour of that if the list owners will take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

