### PR TITLE
Add CF-owned launch_defaults for W&B entity/project resolution

### DIFF
--- a/cosmos_framework/utils/launch_defaults.py
+++ b/cosmos_framework/utils/launch_defaults.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""W&B launch defaults.
+
+``wandb_util`` resolves the W&B entity and project through this module. It has an
+internal counterpart that is deliberately not released: that one also carries
+cluster paths (container images, shared caches) and NVIDIA's shared W&B entity,
+none of which mean anything outside NVIDIA. This file supplies the public
+implementations at the same module path, so the released ``wandb_util`` resolves
+against it.
+
+Both values come from the environment, so runs land wherever the caller is
+already configured to write.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def get_wandb_entity() -> str | None:
+    """Return the W&B entity to log under, or ``None`` to let wandb decide.
+
+    ``None`` is the important default: wandb then resolves the entity itself,
+    using ``WANDB_ENTITY`` when set and otherwise the account the caller is
+    logged in as. A run can only be written to an entity the caller belongs to,
+    so this module must not name a specific team.
+    """
+    return os.environ.get("WANDB_ENTITY") or None
+
+
+def get_wandb_project(config_project: str) -> str:
+    """Return the W&B project, preferring ``WANDB_PROJECT`` over the job config.
+
+    Args:
+        config_project: The project from the job config, used when the
+            environment does not override it.
+    """
+    return os.environ.get("WANDB_PROJECT") or config_project


### PR DESCRIPTION
imaginaire4 recently centralized its launch defaults into imaginaire/utils/launch_defaults.py and rewired wandb_util.py to import get_wandb_entity/get_wandb_project from it. wandb_util.py is release-mapped but launch_defaults.py is not, so the release drift gate fails with

  SOURCE BREAK: imaginaire/utils/wandb_util.py -> cosmos_framework/utils/wandb_util.py
    :: unresolved imaginaire.utils.launch_defaults.get_wandb_entity

The internal module cannot simply be mapped: it carries cluster paths (container image, shared HF cache under /lustre) and NVIDIA's shared W&B entity. Shipping that entity would actively break external users, since a run can only be written to an entity the caller belongs to.

So supply the public implementations at the same module path instead. The drift gate resolves an unmapped internal module against a CF-side file at the module's own dest path (check_drift._is_resolvable), which is exactly this case, and the released wandb_util.py then resolves against this file.

Both values come from the environment, with None entity letting wandb resolve the caller's own account -- the behavior cosmos-framework had before the internal change.