### PR TITLE
ci: run the two-way flex-vs-dense attention test in its own process

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -315,7 +315,32 @@ jobs:
           export LD_LIBRARY_PATH=
           export COSMOS_DOWNLOAD_CACHE_DIR="$RUNNER_WORKSPACE/cosmos_input_cache"
           uv run --all-extras --group=cu128-train python -m pytest -v -s \
-            cosmos_framework/ -o addopts=
+            cosmos_framework/ -o addopts= \
+            --deselect cosmos_framework/model/generator/mot/attention_test.py::test_two_way_attention_flex_matches_dense_across_batch_shapes
+
+      # Deselected above and run here instead, in a process of its own.
+      #
+      # NATTEN's fused-NA knobs are process-global, and
+      # cosmos_framework/model/attention/natten/functions.py turns them on at import time
+      # (set_memory_usage_preference("unrestricted"), use_kv_parallelism_in_fused_na(True))
+      # without ever putting them back. Once test_two_way_attention_vs_three_way_attention --
+      # the one test that dispatches to NATTEN -- has run in a process, this test's
+      # [triton-compile-dynamic] case comes back with NaN for dk across the second sample's
+      # whole UND span (17920/141312 elements, first at index (322, 0, 0)). It passes on its
+      # own, on both H100 and H200, so the two are coupled through process state rather than
+      # through anything either one computes.
+      #
+      # Resetting those knobs between the two tests does clear it, but only from a plugin
+      # loaded with -p; the same code in a conftest, a fixture finaliser or a trylast hook
+      # does not, which is not understood well enough to land as a fix. Separate processes
+      # are what the coupling cannot cross. Tracked in #179.
+      - name: Unit tests - two_way_attention flex vs dense (separate process)
+        run: |
+          export LD_LIBRARY_PATH=
+          export COSMOS_DOWNLOAD_CACHE_DIR="$RUNNER_WORKSPACE/cosmos_input_cache"
+          uv run --all-extras --group=cu128-train python -m pytest -v -s \
+            cosmos_framework/model/generator/mot/attention_test.py::test_two_way_attention_flex_matches_dense_across_batch_shapes \
+            -o addopts=
 
       # The cfgp_ar / context_parallel tests call dist.init_process_group and
       # skip under plain pytest (world_size 1); they must be launched with


### PR DESCRIPTION
Splits the one test that the `unittest` job fails on into a pytest process of its own. Targets #179's branch, since the test it deselects only exists there.

## The failure

`cosmos_framework/model/generator/mot/attention_test.py::test_two_way_attention_flex_matches_dense_across_batch_shapes[triton-compile-dynamic]`:

```
Mismatched elements: 17920 / 141312 (12.7%)
Greatest absolute difference: nan at index (322, 0, 0) (up to 0.01 allowed)
```

Deterministic — two CI attempts produced byte-identical output.

`17920 / 256 = 70` rows starting at index 322. For that shape (`und_lens=(130, 70)`, `token_shapes=((12,4,4),(10,4,4))` → 200 UND + 352 GEN = 552 tokens) the packed layout is:

```
s0.UND 0-130 | s0.GEN 130-322 | s1.UND 322-392 | s1.GEN 392-552
```

So it is the second sample's entire UND span, and nothing else. The forward comparison for the same shape passes and `dq` passes, so the mask geometry is right; only `dk` is wrong.

## What causes it

The test does not fail on its own. It fails only after `test_two_way_attention_vs_three_way_attention` — the one test in the file that dispatches to NATTEN — has run earlier in the same process.

`cosmos_framework/model/attention/natten/functions.py:35-36` runs at import time and never restores:

```python
set_memory_usage_preference("unrestricted")
use_kv_parallelism_in_fused_na(True)
```

That file is untouched by #179; the bug is pre-existing and the new test is what exposes it.

The [NATTEN global-context documentation](https://natten.org/context/#flex-attention-torchcompile) independently warns that Flex Attention with `torch.compile` is experimental and can be incorrect; it specifically calls out intermittent or test-order-dependent failures and cases where forward is correct while backward fails. That closely matches this symptom, but it does not establish that the direct PyTorch FlexAttention path here has the same underlying bug.

## Ruled out

Measured on 8×H100 (sm90) under this job's own pins — torch 2.10.0+cu128, triton 3.6.0 — where the CI failure reproduces bit for bit:

| | |
|---|---|
| Hardware | reproduces on H100; H200 is what CI runs |
| torch / triton version | identical to CI's pins |
| Inductor caches | `TORCHINDUCTOR_FORCE_DISABLE_CACHES=1` still fails |
| Mask construction | the block mask is built eagerly outside `torch.compile`, so `compile_dynamic` cannot change it — and `[triton-compile-static]` passes on the same mask |
| The test itself | passes alone (all 4 params); passes with the order reversed |

Minimal reproducer, 21 seconds:

```sh
pytest "cosmos_framework/model/generator/mot/attention_test.py::test_two_way_attention_vs_three_way_attention" \
       "cosmos_framework/model/generator/mot/attention_test.py::test_two_way_attention_flex_matches_dense_across_batch_shapes[triton-compile-dynamic]"
```

## Why this and not a reset

Resetting the NATTEN knobs between the two tests does clear it — `13 passed` against `1 failed` on the file. But only from a plugin loaded with `-p`. The same two lines in a `conftest.py`, in an autouse fixture's finaliser, under `@pytest.hookimpl(trylast=True)`, or in `pytest_runtest_setup` all leave it failing, and instrumentation shows the flags holding identical values at the start of the flex test in both the passing and the failing configuration. Whatever the `-p` path is really doing is not the flag value, and it is not understood well enough to land as a fix.

Separate processes are what the coupling cannot cross, so that is what this does.

**This is not a fix.** The NATTEN ↔ FlexAttention interaction behind it is still open, and the import-time global mutation applies to any process that imports the NATTEN path, training included — worth its own issue.

## Verification

| | |
|---|---|
| suite as it stands | 1 failed (the NaN), 12 passed |
| the test on its own | 4 params, none failing |
| suite with this change | `10 failed, 971 passed, 30 skipped, 7 deselected` — the NaN failure is gone and nothing else moves |

The 10 remaining failures are pre-existing in the measurement environment (missing HF assets, guardrail, distributed, no git HEAD in a worktree) and are green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
