### PR TITLE
fix(guardrail): whitelist restore corrupts the censored prompt, and invisible characters evade the blocklist

### DIFF
--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import re
+import unicodedata
 from difflib import SequenceMatcher
 
 import nltk
@@ -28,6 +29,12 @@ CENSOR_SENTINEL = "\x00"
 # Displayed to the user in the "Censored Prompt" message. Presentation only --
 # never used to decide whether something was censored.
 CENSOR = misc.Color.red("*")
+
+# Characters that occupy no width, or that only reorder what is drawn: zero-width
+# spaces and joiners, the soft hyphen, and the bidirectional controls. They render
+# as nothing, so a blocklist entry split by one still reads as the entry to a human
+# while reaching the matcher as a token it does not recognise.
+INVISIBLE_CHARS = re.compile(r"[­​-‏‪-‮⁠-⁤﻿]")
 
 
 class Blocklist(ContentSafetyGuardrail):
@@ -60,6 +67,30 @@ class Blocklist(ContentSafetyGuardrail):
         log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
         log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
 
+    @staticmethod
+    def normalize_for_matching(prompt: str) -> str:
+        """Fold away the ways a word can be written to look normal but not match.
+
+        The matcher compares whitespace-delimited tokens, so anything that splits
+        a word without being visible, or that spells its letters with a different
+        code point, walks past it while the prompt still reads as the blocked word.
+        Three foldings, all of them lossless as far as a reader is concerned:
+
+        * compatibility normalization (NFKC), which maps fullwidth and other
+          presentation forms onto the ASCII letters they are drawn as;
+        * removal of combining marks, so an accent added to a letter does not
+          make a new word;
+        * invisible characters rewritten to a space, then runs of whitespace
+          collapsed, so a word split by any of them is matched as the split it
+          renders as.
+
+        The collapse also closes a plainer hole: a multi-word entry was defeated
+        by typing two spaces between its words.
+        """
+        prompt = unicodedata.normalize("NFKC", prompt)
+        prompt = "".join(c for c in unicodedata.normalize("NFKD", prompt) if not unicodedata.combining(c))
+        return " ".join(INVISIBLE_CHARS.sub(" ", prompt).split())
+
     def censor_prompt(self, input_prompt: str) -> tuple[bool, str]:
         """Censor the prompt using the blocklist with better-profanity fuzzy matching.
 
@@ -77,6 +108,7 @@ class Blocklist(ContentSafetyGuardrail):
         # than substituting keeps the stricter reading: "n\x00ike" fuses back to
         # a blocked word instead of being split into two harmless tokens.
         input_prompt = input_prompt.replace(CENSOR_SENTINEL, "")
+        input_prompt = self.normalize_for_matching(input_prompt)
         # The whitelist is handed to load_censor_words(), so the matcher already
         # leaves whitelisted words alone. Restoring them a second time here is
         # what introduced the token misalignment described in the commit message.

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -4,7 +4,6 @@
 import argparse
 import os
 import re
-import string
 from difflib import SequenceMatcher
 
 import nltk
@@ -61,17 +60,6 @@ class Blocklist(ContentSafetyGuardrail):
         log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
         log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
 
-    def uncensor_whitelist(self, input_prompt: str, censored_prompt: str) -> str:
-        """Explicitly uncensor words that are in the whitelist."""
-        input_words = input_prompt.split()
-        censored_words = censored_prompt.split()
-        whitelist_words = set(self.whitelist_words)
-        for i, token in enumerate(input_words):
-            if token.strip(string.punctuation).lower() in whitelist_words:
-                censored_words[i] = token
-        censored_prompt = " ".join(censored_words)
-        return censored_prompt
-
     def censor_prompt(self, input_prompt: str) -> tuple[bool, str]:
         """Censor the prompt using the blocklist with better-profanity fuzzy matching.
 
@@ -89,9 +77,10 @@ class Blocklist(ContentSafetyGuardrail):
         # than substituting keeps the stricter reading: "n\x00ike" fuses back to
         # a blocked word instead of being split into two harmless tokens.
         input_prompt = input_prompt.replace(CENSOR_SENTINEL, "")
+        # The whitelist is handed to load_censor_words(), so the matcher already
+        # leaves whitelisted words alone. Restoring them a second time here is
+        # what introduced the token misalignment described in the commit message.
         censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
-        # Uncensor whitelisted words that were censored from blocklist fuzzy matching
-        censored_prompt = self.uncensor_whitelist(input_prompt, censored_prompt)
         if CENSOR_SENTINEL in censored_prompt:
             display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
             return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
+import unicodedata
+
 import pytest
 
 from cosmos_framework.auxiliary.guardrail.blocklist.blocklist import Blocklist
@@ -242,3 +244,106 @@ def test_punctuation_around_a_whitelisted_word_is_preserved():
 
     assert blocked is True
     assert "flat, wall." in message
+
+
+@pytest.mark.L1
+def test_extra_spaces_do_not_defeat_a_multi_word_entry():
+    """A two-word entry was evaded by typing two spaces between its words."""
+    bl = _blocklist_with_words(["snow white"])
+
+    blocked, _ = bl.censor_prompt("a snow  white poster")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("name", "prompt"),
+    [
+        ("zero width space", "a snow​white poster"),
+        ("zero width non joiner", "a snow‌white poster"),
+        ("soft hyphen", "a snow­white poster"),
+        ("right to left override", "a snow‮white poster"),
+        ("word joiner", "a snow⁠white poster"),
+        ("byte order mark", "a snow﻿white poster"),
+    ],
+)
+def test_invisible_characters_do_not_split_a_blocked_phrase(name, prompt):
+    """An invisible character renders as nothing, so the prompt still reads as the entry.
+
+    Splitting "snow white" with one of these produced a token the matcher did not
+    recognise, while a reader saw the blocked phrase unchanged.
+    """
+    bl = _blocklist_with_words(["snow white"])
+
+    blocked, _ = bl.censor_prompt(prompt)
+
+    assert blocked is True, f"{name} was not folded away"
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("name", "prompt"),
+    [
+        ("non breaking space", "a snow white poster"),
+        ("en quad", "a snow white poster"),
+        ("ideographic space", "a snow　white poster"),
+        ("narrow no break space", "a snow white poster"),
+    ],
+)
+def test_unusual_spaces_do_not_split_a_blocked_phrase(name, prompt):
+    """Any Unicode space between the words of an entry must still match."""
+    bl = _blocklist_with_words(["snow white"])
+
+    blocked, _ = bl.censor_prompt(prompt)
+
+    assert blocked is True, f"{name} was not folded away"
+
+
+@pytest.mark.L1
+def test_fullwidth_letters_are_folded_to_ascii():
+    """Fullwidth forms are drawn as the ASCII letters they normalize to."""
+    bl = _blocklist_with_words(["snow white"])
+
+    blocked, _ = bl.censor_prompt("a ｓｎｏｗ white poster")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_combining_marks_do_not_make_a_new_word():
+    """An accent added to a letter must not create a word the blocklist misses."""
+    bl = _blocklist_with_words(["snow white"])
+
+    for prompt in ("a snów white poster", unicodedata.normalize("NFD", "a snów white poster")):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is True, f"{prompt!r} was not folded away"
+
+
+@pytest.mark.L1
+def test_normalization_does_not_block_ordinary_text():
+    """Folding must not invent matches in text that contains none."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    for prompt in (
+        "a robot on a flat desk",
+        "an em dash — and an arrow → in the text",
+        "café scene with Élodie",
+        "snow  and  white  are  separate  words  here",
+        "こんにちは from the model",
+    ):
+        blocked, message = bl.censor_prompt(prompt)
+        assert blocked is False, f"{prompt!r} was wrongly reported as blocked: {message}"
+
+
+@pytest.mark.L1
+def test_normalization_preserves_the_earlier_sentinel_and_markdown_behaviour():
+    """Folding runs after the sentinel strip and must not resurrect the "*" bug."""
+    bl = _blocklist_with_words(["badword"])
+
+    blocked, _ = bl.censor_prompt("A **bold** heading with ​ in it")
+    assert blocked is False
+
+    blocked, message = bl.censor_prompt("a bad\x00word in the text")
+    assert blocked is True
+    assert "badword" not in message

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -45,7 +45,7 @@ def test_partial_match_with_threshold():
     assert match is False
 
 
-def _blocklist_with_words(words: list[str]) -> Blocklist:
+def _blocklist_with_words(words: list[str], whitelist: list[str] | None = None) -> Blocklist:
     """Build a Blocklist around a small word list, without downloading a checkpoint.
 
     censor_prompt only needs the profanity matcher and the whitelist, so the
@@ -53,10 +53,11 @@ def _blocklist_with_words(words: list[str]) -> Blocklist:
     """
     from better_profanity.better_profanity import Profanity
 
+    whitelist = whitelist or []
     bl = Blocklist.__new__(Blocklist)
     bl.profanity = Profanity()
-    bl.profanity.load_censor_words(custom_words=words, whitelist_words=[])
-    bl.whitelist_words = []
+    bl.profanity.load_censor_words(custom_words=words, whitelist_words=whitelist)
+    bl.whitelist_words = whitelist
     return bl
 
 
@@ -126,3 +127,118 @@ def test_blocked_word_is_still_detected_alongside_markdown():
     # blocked word is masked.
     assert "**bold**" in message
     assert "badword" not in message
+
+
+@pytest.mark.L1
+def test_multi_word_match_beside_whitelisted_word_does_not_crash():
+    """A multi-word blocklist hit must not make a later whitelisted word crash.
+
+    Regression test: the censored text has one token per match, so a two-word
+    entry made it one token shorter than the input. The whitelist restore walked
+    the two lists by position, so a whitelisted word after the match indexed past
+    the end of the censored list and raised IndexError on an ordinary prompt.
+    """
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("Snow White is flat")
+
+    assert blocked is True
+    assert "is flat" in message
+
+
+@pytest.mark.L1
+def test_multi_word_match_does_not_rewrite_a_later_word():
+    """The reported prompt must quote the input, not a shifted copy of it.
+
+    Same off-by-N as above, but landing inside the list instead of past its end:
+    the write went to the wrong token and silently replaced it.
+    """
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("a Snow White poster on a flat wall")
+
+    assert blocked is True
+    assert "on a flat wall" in message
+    assert "flat flat" not in message
+
+
+@pytest.mark.L1
+def test_several_multi_word_matches_stay_aligned():
+    """Every additional multi-word hit shifts the two lists one token further."""
+    bl = _blocklist_with_words(["snow white", "boston dynamics"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("Snow White and Boston Dynamics on a flat wall")
+
+    assert blocked is True
+    assert "on a flat wall" in message
+
+
+@pytest.mark.L1
+def test_whitelisted_word_is_not_censored():
+    """The whitelist still works: a whitelisted word is reported as written."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("a Snow White poster on a flat desk")
+
+    assert blocked is True
+    assert "a flat desk" in message
+
+
+@pytest.mark.L1
+def test_whitelisted_word_alone_does_not_block():
+    """A prompt with only whitelisted words is safe."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("the floor is flat")
+
+    assert blocked is False
+    assert message == ""
+
+
+@pytest.mark.L1
+def test_whitelisted_word_inside_a_blocked_phrase_stays_censored():
+    """A whitelisted word must not dissolve a phrase that genuinely matched.
+
+    'snow flat' is on the blocklist and 'flat' is whitelisted. The phrase is the
+    match, so it stays censored; whitelisting a word does not license the phrase
+    that contains it.
+    """
+    bl = _blocklist_with_words(["snow flat"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("a snow flat scene")
+
+    assert blocked is True
+    assert "snow flat" not in message
+
+
+@pytest.mark.L1
+def test_whitelisted_word_at_the_end_of_the_prompt():
+    """The final token is where the positional walk ran off the end."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("a snow white poster flat")
+
+    assert blocked is True
+    assert message.endswith("poster flat")
+
+
+@pytest.mark.L1
+def test_repeated_multi_word_matches():
+    """Two hits in a row shift the alignment twice over."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("snow white snow white flat wall")
+
+    assert blocked is True
+    assert "flat wall" in message
+
+
+@pytest.mark.L1
+def test_punctuation_around_a_whitelisted_word_is_preserved():
+    """Punctuation belongs to the token and must survive into the message."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat"])
+
+    blocked, message = bl.censor_prompt("snow white, flat, wall.")
+
+    assert blocked is True
+    assert "flat, wall." in message


### PR DESCRIPTION
# fix(guardrail): whitelist restore corrupts the censored prompt, and invisible characters evade the blocklist

Two independent defects in `Blocklist.censor_prompt`, one commit each.

## 1. The whitelist restore wrote to the wrong token

`censor_prompt` censored the prompt, then walked the input and the censored text
side by side to put whitelisted words back:

```python
input_words = input_prompt.split()
censored_words = censored_prompt.split()
for i, token in enumerate(input_words):
    if token.strip(string.punctuation).lower() in whitelist_words:
        censored_words[i] = token
```

This assumes token `i` of the input is token `i` of the censored text. It is not.
A blocklist entry made of several words is replaced by a **single** censor token,
so every multi-word match makes the censored list one token shorter and shifts
everything after it to the left.

The production list has 95 multi-word entries out of 383, and the whitelist is the
single word `flat`, so both halves of the failure are reachable from ordinary
prompts.

**It crashes** when the shift runs off the end:

```
'Snow White is flat'
    input    -> [Snow] [White] [is] [flat]    4 tokens
    censored -> [****] [is] [flat]            3 tokens
    'flat' is at input index 3 -> no such index in the censored list

IndexError: list assignment index out of range
```

Reproduced against the production checkpoint through `Blocklist()` itself, not a
test double. A benign prompt takes the guardrail down rather than returning a
verdict.

**It silently corrupts** when the shift stays in range:

```
'a Snow White poster on a flat wall'
    input    -> ... [a] [flat] [wall]   'flat' is at index 6
    censored -> ... [a] [flat] [wall]   index 6 is 'wall'

user is shown:  'a **** poster on a flat flat'      <- 'wall' overwritten
```

No exception. The prompt quoted back to the user is not the prompt they sent.

### The fix: remove the restore step

It is not needed. The whitelist is already passed to
`load_censor_words(whitelist_words=...)`, so the matcher leaves whitelisted words
alone on its own — with the production lists, a prompt containing only whitelisted
words comes back from `censor()` untouched.

So the loop only ever had work to do when a whitelisted word sat **inside** a
longer match, and in that case putting it back is the wrong thing to do anyway: it
would dissolve a phrase that genuinely matched. `'a snow flat scene'`, with
`snow flat` blocked and `flat` whitelisted, must stay blocked.

Deleting it fixes both failures and needs no replacement logic.

## 2. Invisible characters walked past the matcher

The matcher compares whitespace-delimited tokens, so a prompt only has to reach it
as a *different token* to get past it. It does not have to look different to a
reader. Measured against the production lists:

| prompt | before | after |
|---|---|---|
| `a snow white poster` | blocked | blocked |
| `a snow  white poster` (two spaces) | **not blocked** | blocked |
| `a snow<U+200B>white poster` (zero-width space) | **not blocked** | blocked |
| `a snow<U+00AD>white poster` (soft hyphen) | **not blocked** | blocked |
| `a <fullwidth>snow</fullwidth> white poster` | **not blocked** | blocked |
| `a sno<combining acute>w white poster` | **not blocked** | blocked |

The zero-width case is the one worth pausing on: nothing distinguishes the evading
prompt from the plain one on screen, in a log, or in a review.

`normalize_for_matching()` folds these before censoring — NFKC, combining marks
dropped, invisible and bidirectional-control characters rewritten to a space, then
whitespace runs collapsed.

**This blocks strictly more than before.** It is a deliberate strictness increase
rather than a bug fix, which is why it is a separate commit — merge the first
alone if you would rather take the strictness question separately.

**Not addressed: homoglyphs.** A Cyrillic `о` in place of an ASCII one is drawn
identically and still evades, before and after this change. Folding it needs a
confusables mapping (UTS #39) and a decision about which skeletons to apply. That
is its own change, not a line in this one, and I have filed it separately rather
than leaving it implied.

## Tests

`blocklist_test.py` goes from 8 to 32 tests. All 32 pass; **20 of the 24 new ones
fail without the corresponding code change**, checked by reverting `blocklist.py`
and re-running.

For the alignment fix — the crash, the silent rewrite, several multi-word matches
in one prompt, a whitelisted word at the very end, repeated matches, punctuation
attached to a whitelisted word. Plus two guards that pass either way and are meant
to: the whitelist still works, and a whitelisted word does not dissolve a phrase
that matched.

For the normalisation — the double space, six invisible characters, four Unicode
spaces, fullwidth letters, combining marks in both composed and decomposed form.
Plus a false-positive guard over ordinary text that the folding touches (em dash,
arrow, accented names, CJK) and a check that the earlier sentinel and Markdown
behaviour is unchanged.

The tests build the matcher directly rather than downloading a checkpoint, so they
are hermetic.

## Corpus check

Both commits were measured over the 492 outputs of the Edge reasoner QA sweep with
the production lists. **The same 4 items block before and after, item for item, no
new blocks, no crashes.**

That corpus does exercise the folding — 69 of the 492 outputs contain non-ASCII
characters, including accented Latin letters that the mark-stripping actively
rewrites, and 58 contain a double space. It contains no zero-width characters and
no fullwidth text, so those paths are covered by the tests rather than by the
corpus. Worth stating rather than presenting 492/492 as coverage it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
