### PR TITLE
fix(guardrail): let the whitelist hold phrases, so ordinary prose stops matching blocklist entries

### DIFF
--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -79,6 +79,19 @@ class Blocklist(ContentSafetyGuardrail):
         log.debug(f"Whitelisted {len(whitelist_tokens)} words and {len(self.whitelist_phrases)} phrases")
         log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
 
+        for token in self.unprotected_whitelist_tokens(self.profanity, whitelist_tokens):
+            # better_profanity drops a whitelisted word before it expands the
+            # leetspeak variants of the other entries, so a whitelisted word can
+            # still be censored as some *other* entry's variant -- "flat" is what
+            # "fiat" becomes under the i/l mapping. Whitelisting it then silently
+            # does nothing, which is worth saying out loud at load time.
+            log.warning(f"Whitelisted word is still censored as a variant of another blocklist entry: {token!r}")
+
+    @staticmethod
+    def unprotected_whitelist_tokens(matcher, whitelist_tokens: list[str]) -> list[str]:
+        """Whitelisted words the loaded matcher censors anyway."""
+        return [token for token in whitelist_tokens if matcher.censor(token, censor_char=CENSOR_SENTINEL) != token]
+
     @staticmethod
     def normalize_for_matching(prompt: str) -> str:
         """Fold away the ways a word can be written to look normal but not match.

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import re
+import string
 import unicodedata
 from difflib import SequenceMatcher
 
@@ -36,11 +37,9 @@ CENSOR = misc.Color.red("*")
 # while reaching the matcher as a token it does not recognise.
 INVISIBLE_CHARS = re.compile(r"[­​-‏‪-‮⁠-⁤﻿]")
 
-# Placeholder a whitelisted phrase is replaced with before matching. It has to
-# be a single token that no blocklist entry can fuse with or fuzzy-match, and it
-# has to survive to_ascii, so it is plain lowercase ASCII with no separators.
-WHITELIST_MASK_PREFIX = "zzwhitelisted"
-WHITELIST_MASK_SUFFIX = "zz"
+# Punctuation trimmed from a token before it is compared with a whitelisted
+# phrase, so "a desk in, the corner" still matches the phrase "desk in".
+_STRIP_CHARS = string.punctuation
 
 
 class Blocklist(ContentSafetyGuardrail):
@@ -69,8 +68,8 @@ class Blocklist(ContentSafetyGuardrail):
         self.exact_match_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "exact_match"))
 
         # The matcher's whitelist is a set of single tokens, so a whitelisted
-        # phrase never reaches it. Phrases are handled here instead, by masking
-        # them out of the prompt before matching -- see mask_whitelisted_phrases.
+        # phrase never reaches it. Phrases are handled in censor_prompt instead,
+        # by exempting the matches that fall inside one.
         self.whitelist_phrases = sorted((w for w in self.whitelist_words if " " in w.strip()), key=len, reverse=True)
         whitelist_tokens = [w for w in self.whitelist_words if " " not in w.strip()]
 
@@ -129,38 +128,60 @@ class Blocklist(ContentSafetyGuardrail):
         """Rewrite zero-width and bidirectional characters to a space."""
         return " ".join(INVISIBLE_CHARS.sub(" ", prompt).split())
 
-    def mask_whitelisted_phrases(self, prompt: str) -> tuple[str, dict[str, str]]:
-        """Replace whitelisted phrases with placeholders, before matching.
+    @staticmethod
+    def align_folded_to_source(source: list[str], folded: list[str]) -> list[int]:
+        """For each folded token, the index of the source token it came from.
 
-        The matcher fuses adjacent words and tests the fused string against the
-        blocklist, which is how "n ike" is caught. The same fusing means a
-        blocklist entry spelled out of two ordinary words also matches the prose
-        that contains them: "a desk in the background" fuses into an entry.
-
-        Whitelisting the innocent halves cannot fix that -- the fusing does not
-        consult the whitelist, and the halves are ordinary words that should not
-        be exempt on their own. Whitelisting the *phrase* can: the placeholder
-        does not fuse into anything, so exactly one spelling stops matching, and
-        every other spelling of the entry ("d eskin", "de sk in", leetspeak) is
-        still caught.
-
-        Placeholders are single tokens, so the token count is unchanged and the
-        censored output lines up with the input.
-
-        This runs before invisible characters are folded to spaces, and that
-        order matters: "desk<U+200B>in" renders as the entry with no space in it,
-        and folding first would turn it into the whitelisted phrase and exempt an
-        evasion that a reader cannot see. Matching the phrase while the invisible
-        character is still there leaves that spelling blocked.
+        Folding invisible characters to a space can split one source token into
+        several, so the two streams are not index-for-index. Walk them together,
+        consuming folded tokens until their concatenation reproduces the source
+        token, which is exactly what the fold did to it.
         """
-        replacements = {}
-        for index, phrase in enumerate(self.whitelist_phrases):
-            placeholder = f"{WHITELIST_MASK_PREFIX}{index}{WHITELIST_MASK_SUFFIX}"
-            pattern = re.compile(r"\b" + re.escape(phrase.strip()) + r"\b", re.IGNORECASE)
-            prompt, count = pattern.subn(placeholder, prompt)
-            if count:
-                replacements[placeholder] = phrase
-        return prompt, replacements
+        mapping: list[int] = []
+        source_index = 0
+        buffer = ""
+        for token in folded:
+            mapping.append(min(source_index, len(source) - 1))
+            buffer += token
+            while (
+                source_index < len(source)
+                and buffer
+                and len(buffer) >= len(INVISIBLE_CHARS.sub("", source[source_index]))
+            ):
+                buffer = ""
+                source_index += 1
+        return mapping
+
+    @staticmethod
+    def censored_token_spans(source_tokens: list[str], censored_tokens: list[str]) -> list[tuple[int, int]]:
+        """(start, end) indices of every censored run, end exclusive.
+
+        The matcher replaces a matched span -- which may cover several tokens --
+        with a single censored token, so the two streams differ in length by
+        exactly the number of tokens the matches swallowed.
+        """
+        spans: list[tuple[int, int]] = []
+        source_index = 0
+        for position, token in enumerate(censored_tokens):
+            if CENSOR_SENTINEL in token:
+                width = (len(source_tokens) - source_index) - (len(censored_tokens) - position) + 1
+                width = max(1, width)
+                spans.append((source_index, source_index + width))
+                source_index += width
+            else:
+                source_index += 1
+        return spans
+
+    def whitelisted_phrase_spans(self, tokens: list[str]) -> list[tuple[int, int]]:
+        """(start, end) token indices of every whitelisted phrase occurrence."""
+        lowered = [token.strip(_STRIP_CHARS).lower() for token in tokens]
+        spans: list[tuple[int, int]] = []
+        for phrase in self.whitelist_phrases:
+            parts = phrase.strip().lower().split()
+            for start in range(len(lowered) - len(parts) + 1):
+                if lowered[start : start + len(parts)] == parts:
+                    spans.append((start, start + len(parts)))
+        return spans
 
     def censor_prompt(self, input_prompt: str) -> tuple[bool, str]:
         """Censor the prompt using the blocklist with better-profanity fuzzy matching.
@@ -185,15 +206,39 @@ class Blocklist(ContentSafetyGuardrail):
         # Whitelisted phrases never reach the matcher, so they are masked here --
         # between the two foldings, for the reason given in that method.
         input_prompt = self.normalize_code_points(input_prompt)
-        input_prompt, masked_phrases = self.mask_whitelisted_phrases(input_prompt)
-        input_prompt = self.fold_invisible_characters(input_prompt)
-        censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
-        if CENSOR_SENTINEL in censored_prompt:
-            display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
-            for placeholder, phrase in masked_phrases.items():
-                display_prompt = display_prompt.replace(placeholder, phrase)
-            return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"
-        return False, ""
+
+        # Phrase occurrences are located before invisible characters are folded,
+        # and that order matters: "desk<U+200B>in" renders as the entry with no
+        # space in it, so folding first would turn an evasion into the
+        # whitelisted phrase and exempt it.
+        source_tokens = input_prompt.split()
+        exempt_spans = self.whitelisted_phrase_spans(source_tokens)
+
+        folded_prompt = self.fold_invisible_characters(input_prompt)
+        censored_prompt = self.profanity.censor(folded_prompt, censor_char=CENSOR_SENTINEL)
+        if CENSOR_SENTINEL not in censored_prompt:
+            return False, ""
+
+        # The exemption is applied to the matches, not to the prompt. Masking the
+        # phrase out before matching would also delete any match that overlaps
+        # it; dropping only the matches that lie entirely inside a whitelisted
+        # phrase leaves the ones that straddle its boundary blocked.
+        folded_tokens = folded_prompt.split()
+        to_source = self.align_folded_to_source(source_tokens, folded_tokens)
+        remaining = []
+        for start, end in self.censored_token_spans(folded_tokens, censored_prompt.split()):
+            first = to_source[min(start, len(to_source) - 1)] if to_source else 0
+            last = to_source[min(end - 1, len(to_source) - 1)] if to_source else 0
+            if not any(low <= first and last < high for low, high in exempt_spans):
+                remaining.append((start, end))
+        if not remaining:
+            return False, ""
+
+        display_tokens = list(folded_tokens)
+        for start, end in remaining:
+            for index in range(start, min(end, len(display_tokens))):
+                display_tokens[index] = CENSOR
+        return True, f"Prompt blocked by censorship: Censored Prompt: {' '.join(display_tokens)}"
 
     @staticmethod
     def check_partial_match(

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist.py
@@ -36,6 +36,12 @@ CENSOR = misc.Color.red("*")
 # while reaching the matcher as a token it does not recognise.
 INVISIBLE_CHARS = re.compile(r"[­​-‏‪-‮⁠-⁤﻿]")
 
+# Placeholder a whitelisted phrase is replaced with before matching. It has to
+# be a single token that no blocklist entry can fuse with or fuzzy-match, and it
+# has to survive to_ascii, so it is plain lowercase ASCII with no separators.
+WHITELIST_MASK_PREFIX = "zzwhitelisted"
+WHITELIST_MASK_SUFFIX = "zz"
+
 
 class Blocklist(ContentSafetyGuardrail):
     def __init__(
@@ -62,9 +68,15 @@ class Blocklist(ContentSafetyGuardrail):
         self.whitelist_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "whitelist"))
         self.exact_match_words = read_keyword_list_from_dir(os.path.join(self.checkpoint_dir, "exact_match"))
 
-        self.profanity.load_censor_words(custom_words=self.blocklist_words, whitelist_words=self.whitelist_words)
+        # The matcher's whitelist is a set of single tokens, so a whitelisted
+        # phrase never reaches it. Phrases are handled here instead, by masking
+        # them out of the prompt before matching -- see mask_whitelisted_phrases.
+        self.whitelist_phrases = sorted((w for w in self.whitelist_words if " " in w.strip()), key=len, reverse=True)
+        whitelist_tokens = [w for w in self.whitelist_words if " " not in w.strip()]
+
+        self.profanity.load_censor_words(custom_words=self.blocklist_words, whitelist_words=whitelist_tokens)
         log.debug(f"Loaded {len(self.blocklist_words)} words/phrases from blocklist")
-        log.debug(f"Whitelisted {len(self.whitelist_words)} words/phrases from whitelist")
+        log.debug(f"Whitelisted {len(whitelist_tokens)} words and {len(self.whitelist_phrases)} phrases")
         log.debug(f"Loaded {len(self.exact_match_words)} exact match words/phrases from blocklist")
 
     @staticmethod
@@ -86,10 +98,56 @@ class Blocklist(ContentSafetyGuardrail):
 
         The collapse also closes a plainer hole: a multi-word entry was defeated
         by typing two spaces between its words.
+
+        The two foldings are separate methods because a whitelisted phrase has to
+        be matched between them: see censor_prompt.
         """
+        return Blocklist.fold_invisible_characters(Blocklist.normalize_code_points(prompt))
+
+    @staticmethod
+    def normalize_code_points(prompt: str) -> str:
+        """NFKC, combining marks removed, runs of whitespace collapsed."""
         prompt = unicodedata.normalize("NFKC", prompt)
         prompt = "".join(c for c in unicodedata.normalize("NFKD", prompt) if not unicodedata.combining(c))
+        return " ".join(prompt.split())
+
+    @staticmethod
+    def fold_invisible_characters(prompt: str) -> str:
+        """Rewrite zero-width and bidirectional characters to a space."""
         return " ".join(INVISIBLE_CHARS.sub(" ", prompt).split())
+
+    def mask_whitelisted_phrases(self, prompt: str) -> tuple[str, dict[str, str]]:
+        """Replace whitelisted phrases with placeholders, before matching.
+
+        The matcher fuses adjacent words and tests the fused string against the
+        blocklist, which is how "n ike" is caught. The same fusing means a
+        blocklist entry spelled out of two ordinary words also matches the prose
+        that contains them: "a desk in the background" fuses into an entry.
+
+        Whitelisting the innocent halves cannot fix that -- the fusing does not
+        consult the whitelist, and the halves are ordinary words that should not
+        be exempt on their own. Whitelisting the *phrase* can: the placeholder
+        does not fuse into anything, so exactly one spelling stops matching, and
+        every other spelling of the entry ("d eskin", "de sk in", leetspeak) is
+        still caught.
+
+        Placeholders are single tokens, so the token count is unchanged and the
+        censored output lines up with the input.
+
+        This runs before invisible characters are folded to spaces, and that
+        order matters: "desk<U+200B>in" renders as the entry with no space in it,
+        and folding first would turn it into the whitelisted phrase and exempt an
+        evasion that a reader cannot see. Matching the phrase while the invisible
+        character is still there leaves that spelling blocked.
+        """
+        replacements = {}
+        for index, phrase in enumerate(self.whitelist_phrases):
+            placeholder = f"{WHITELIST_MASK_PREFIX}{index}{WHITELIST_MASK_SUFFIX}"
+            pattern = re.compile(r"\b" + re.escape(phrase.strip()) + r"\b", re.IGNORECASE)
+            prompt, count = pattern.subn(placeholder, prompt)
+            if count:
+                replacements[placeholder] = phrase
+        return prompt, replacements
 
     def censor_prompt(self, input_prompt: str) -> tuple[bool, str]:
         """Censor the prompt using the blocklist with better-profanity fuzzy matching.
@@ -108,13 +166,19 @@ class Blocklist(ContentSafetyGuardrail):
         # than substituting keeps the stricter reading: "n\x00ike" fuses back to
         # a blocked word instead of being split into two harmless tokens.
         input_prompt = input_prompt.replace(CENSOR_SENTINEL, "")
-        input_prompt = self.normalize_for_matching(input_prompt)
-        # The whitelist is handed to load_censor_words(), so the matcher already
-        # leaves whitelisted words alone. Restoring them a second time here is
-        # what introduced the token misalignment described in the commit message.
+        # Whitelisted single words are handed to load_censor_words(), so the
+        # matcher already leaves them alone; restoring them a second time after
+        # censoring is what introduced the token misalignment removed earlier.
+        # Whitelisted phrases never reach the matcher, so they are masked here --
+        # between the two foldings, for the reason given in that method.
+        input_prompt = self.normalize_code_points(input_prompt)
+        input_prompt, masked_phrases = self.mask_whitelisted_phrases(input_prompt)
+        input_prompt = self.fold_invisible_characters(input_prompt)
         censored_prompt = self.profanity.censor(input_prompt, censor_char=CENSOR_SENTINEL)
         if CENSOR_SENTINEL in censored_prompt:
             display_prompt = censored_prompt.replace(CENSOR_SENTINEL, CENSOR)
+            for placeholder, phrase in masked_phrases.items():
+                display_prompt = display_prompt.replace(placeholder, phrase)
             return True, f"Prompt blocked by censorship: Censored Prompt: {display_prompt}"
         return False, ""
 
@@ -226,6 +290,7 @@ class Blocklist(ContentSafetyGuardrail):
         # Check if the input is empty
         if not input_prompt:
             return False, "Input is empty"
+
         input_prompt = to_ascii(input_prompt)
 
         # Check full sentence for censored words

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -431,3 +431,26 @@ def test_phrase_exemption_survives_spacing_and_case():
     for prompt in ("a desk in the room", "a desk  in the room", "a DESK IN the room", "Desk In The Room"):
         blocked, _ = bl.censor_prompt(prompt)
         assert blocked is False, f"{prompt!r} was blocked"
+
+
+@pytest.mark.L1
+def test_whitelisted_word_censored_as_another_entrys_variant_is_reported():
+    """Whitelisting a word does not guarantee the matcher spares it.
+
+    better_profanity removes whitelisted words before it expands the leetspeak
+    variants of the remaining entries, so a whitelisted word that happens to be
+    a variant of another entry stays censored -- "flat" is what "fiat" becomes
+    under the i/l mapping. The whitelist entry then silently does nothing, so
+    the loader names it rather than leaving it to be found in production.
+    """
+    from better_profanity.better_profanity import Profanity
+
+    matcher = Profanity()
+    matcher.load_censor_words(custom_words=["fiat"], whitelist_words=["flat"])
+
+    assert Blocklist.unprotected_whitelist_tokens(matcher, ["flat"]) == ["flat"]
+
+    unaffected = Profanity()
+    unaffected.load_censor_words(custom_words=["snow white"], whitelist_words=["flat"])
+
+    assert Blocklist.unprotected_whitelist_tokens(unaffected, ["flat"]) == []

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -56,10 +56,12 @@ def _blocklist_with_words(words: list[str], whitelist: list[str] | None = None) 
     from better_profanity.better_profanity import Profanity
 
     whitelist = whitelist or []
+    tokens = [w for w in whitelist if " " not in w.strip()]
     bl = Blocklist.__new__(Blocklist)
     bl.profanity = Profanity()
-    bl.profanity.load_censor_words(custom_words=words, whitelist_words=whitelist)
+    bl.profanity.load_censor_words(custom_words=words, whitelist_words=tokens)
     bl.whitelist_words = whitelist
+    bl.whitelist_phrases = sorted((w for w in whitelist if " " in w.strip()), key=len, reverse=True)
     return bl
 
 
@@ -347,3 +349,85 @@ def test_normalization_preserves_the_earlier_sentinel_and_markdown_behaviour():
     blocked, message = bl.censor_prompt("a bad\x00word in the text")
     assert blocked is True
     assert "badword" not in message
+
+
+@pytest.mark.L1
+def test_whitelisted_phrase_clears_the_prose_that_fuses_into_an_entry():
+    """The reported false positive: "desk" + "in" fuses into the entry "deskin".
+
+    Whitelisting the phrase exempts that one spelling. Whitelisting either half
+    on its own cannot: the fusing does not consult the whitelist.
+    """
+    bl = _blocklist_with_words(["deskin"], whitelist=["desk in"])
+
+    blocked, message = bl.censor_prompt("a robot sitting at a desk in the background")
+
+    assert blocked is False, message
+
+
+@pytest.mark.L1
+def test_whitelisting_a_phrase_leaves_every_other_spelling_blocked():
+    """The exemption is one spelling wide, not a hole in the entry."""
+    bl = _blocklist_with_words(["deskin"], whitelist=["desk in"])
+
+    for prompt in (
+        "deskin the animal",
+        "d eskin the animal",
+        "de skin the animal",
+        "des kin the animal",
+        "de sk in the animal",
+        "d3skin the animal",
+    ):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is True, f"{prompt!r} was not blocked"
+
+
+@pytest.mark.L1
+def test_whitelisted_phrase_is_restored_in_the_blocked_message():
+    """The placeholder is internal; the user-facing quote shows their own words."""
+    bl = _blocklist_with_words(["deskin", "badword"], whitelist=["desk in"])
+
+    blocked, message = bl.censor_prompt("a badword next to a desk in the room")
+
+    assert blocked is True
+    assert "desk in" in message
+    assert "zzwhitelisted" not in message
+
+
+@pytest.mark.L1
+def test_whitelisted_word_behaviour_is_unchanged_by_phrase_support():
+    """Single-word whitelisting still goes to the matcher, as before."""
+    bl = _blocklist_with_words(["snow white"], whitelist=["flat", "desk in"])
+
+    blocked, _ = bl.censor_prompt("the floor is flat")
+    assert blocked is False
+
+    blocked, _ = bl.censor_prompt("a Snow White poster on a flat wall")
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_invisible_character_cannot_reach_the_phrase_exemption():
+    """An exemption must not be reachable by a spelling the reader cannot see.
+
+    "desk<U+200B>in" renders as the entry with nothing between its halves. The
+    invisible character is folded to a space for matching, which would turn it
+    into the whitelisted phrase, so the phrase is matched before that folding.
+    """
+    bl = _blocklist_with_words(["deskin"], whitelist=["desk in"])
+
+    blocked, _ = bl.censor_prompt("desk​in the animal")
+    assert blocked is True
+
+    blocked, _ = bl.censor_prompt("desk­in the animal")
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_phrase_exemption_survives_spacing_and_case():
+    """The exempted spelling is the phrase as a reader writes it, however spaced."""
+    bl = _blocklist_with_words(["deskin"], whitelist=["desk in"])
+
+    for prompt in ("a desk in the room", "a desk  in the room", "a DESK IN the room", "Desk In The Room"):
+        blocked, _ = bl.censor_prompt(prompt)
+        assert blocked is False, f"{prompt!r} was blocked"

--- a/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/blocklist_test.py
@@ -454,3 +454,47 @@ def test_whitelisted_word_censored_as_another_entrys_variant_is_reported():
     unaffected.load_censor_words(custom_words=["snow white"], whitelist_words=["flat"])
 
     assert Blocklist.unprotected_whitelist_tokens(unaffected, ["flat"]) == []
+
+
+@pytest.mark.L1
+def test_match_straddling_a_whitelisted_phrase_stays_blocked():
+    """The exemption covers the phrase, not everything that touches it.
+
+    Masking the phrase out before matching also deleted any match that overlaps
+    it: with "in gun" on the blocklist, "a desk in gun on the table" stopped
+    being blocked as soon as "desk in" was whitelisted. Only a match lying
+    entirely inside the phrase may be dropped.
+    """
+    bl = _blocklist_with_words(["in gun"], whitelist=["desk in"])
+
+    blocked, _ = bl.censor_prompt("a desk in gun on the table")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_second_occurrence_of_a_phrase_does_not_hide_a_real_match():
+    """One exempt occurrence must not exempt a different match elsewhere."""
+    bl = _blocklist_with_words(["deskin", "in gun"], whitelist=["desk in"])
+
+    blocked, _ = bl.censor_prompt("a desk in room and a desk in gun")
+
+    assert blocked is True
+
+
+@pytest.mark.L1
+def test_censored_token_spans_locate_a_multi_token_match():
+    """A multi-word match collapses to one censored token; recover its width."""
+    source = "a snow white poster on a wall".split()
+    censored = "a \x00 poster on a wall".split()
+
+    assert Blocklist.censored_token_spans(source, censored) == [(1, 3)]
+
+
+@pytest.mark.L1
+def test_align_folded_to_source_maps_a_split_token_back():
+    """Folding an invisible character splits one source token into two."""
+    source = ["a", "desk​in", "room"]
+    folded = ["a", "desk", "in", "room"]
+
+    assert Blocklist.align_folded_to_source(source, folded) == [0, 1, 1, 2]

--- a/cosmos_framework/auxiliary/guardrail/blocklist/hygiene.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/hygiene.py
@@ -111,19 +111,32 @@ def read_keyword_files(directory: str | Path) -> list[str]:
 def build_reachability_probe(
     blocklist_words: Iterable[str], whitelist_words: Iterable[str] = ()
 ) -> Callable[[str, str], bool]:
-    """Return a predicate telling whether the matcher really blocks a split.
+    """Return a predicate telling whether the deployed path really blocks a split.
 
-    A split is only a problem if the deployed matcher fires on the spaced form;
+    A split is only a problem if the deployed path fires on the spaced form;
     this drops splits that are theoretical for the list being checked.
+
+    The probe runs censor_prompt, not a bare matcher. A whitelist entry that is
+    a phrase never reaches better_profanity -- exempting it is something
+    censor_prompt does on top -- so a bare matcher would keep reporting a split
+    as reachable after the phrase had been whitelisted, which is the remedy this
+    tool prints. The advice has to be checkable by the check that gives it.
     """
     from better_profanity.better_profanity import Profanity
 
-    matcher = Profanity()
-    matcher.load_censor_words(custom_words=list(blocklist_words), whitelist_words=list(whitelist_words))
+    from cosmos_framework.auxiliary.guardrail.blocklist.blocklist import Blocklist
+
+    whitelist = list(whitelist_words)
+    tokens = [w for w in whitelist if " " not in w.strip()]
+
+    probe_blocklist = Blocklist.__new__(Blocklist)
+    probe_blocklist.profanity = Profanity()
+    probe_blocklist.profanity.load_censor_words(custom_words=list(blocklist_words), whitelist_words=tokens)
+    probe_blocklist.whitelist_words = whitelist
+    probe_blocklist.whitelist_phrases = sorted((w for w in whitelist if " " in w.strip()), key=len, reverse=True)
 
     def is_reachable(left: str, right: str) -> bool:
-        probe = PROBE_TEMPLATE.format(left=left, right=right)
-        return matcher.censor(probe, censor_char="\x00") != probe
+        return probe_blocklist.censor_prompt(PROBE_TEMPLATE.format(left=left, right=right))[0]
 
     return is_reachable
 
@@ -248,7 +261,14 @@ def main(argv=None) -> int:
     is_reachable = None
     if source:
         whitelist = read_keyword_files(args.whitelist_dir) if args.whitelist_dir else []
-        is_reachable = build_reachability_probe(read_keyword_files(source), whitelist)
+        entries = read_keyword_files(source)
+        if args.mode == "gate":
+            # The candidate is not on the list yet -- that is the point of the
+            # gate. Probing a matcher built only from the existing list can
+            # never fire on the candidate's own split, so every split would be
+            # discarded as unreachable and the gate would pass anything.
+            entries = entries + list(args.entry)
+        is_reachable = build_reachability_probe(entries, whitelist)
 
     return _cmd_gate(args, is_word, is_reachable) if args.mode == "gate" else _cmd_audit(args, is_word, is_reachable)
 

--- a/cosmos_framework/auxiliary/guardrail/blocklist/hygiene.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/hygiene.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""Hygiene check for blocklist entries that ordinary prose can trip.
+
+`better_profanity` catches evasions such as "n ike" by fusing adjacent tokens
+and testing the fused string against the blocklist. The side effect is that a
+single-word entry which is itself two ordinary English words glued together
+also matches ordinary prose: the entry "deskin" blocks "a robot sitting at a
+desk in the background", because "desk" + "in" fuses back into the entry.
+
+The check is purely syntactic -- it asks whether an entry has a two-way split
+whose halves are both dictionary words -- so it flags entries whose split is
+grammatical but not idiomatic ("deskinning" -> "desk" + "inning") alongside the
+ones prose really produces. It is therefore meant to be read by a list owner,
+not to auto-delete entries. Multi-word entries are never flagged: they cannot
+be fused out of prose.
+
+The remedy for a flagged entry is to whitelist the phrase it collides with:
+"desk in" on the whitelist exempts that one spelling while every other spelling
+of the entry stays blocked. Moving the entry to the exact-match list also works
+but gives up more -- it stops the fused and leetspeak spellings from matching at
+all. Either way the decision belongs to the list owners.
+
+Two modes:
+
+    gate    check candidate entries before they are added to the list; exits
+            non-zero if any candidate is flagged, so it can run in CI.
+
+    audit   report which entries already on a list have the shape.
+
+The audit prints entry text only with --show-entries, so its default output can
+be pasted into a ticket without reproducing content-safety terms.
+"""
+
+import argparse
+import sys
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+# A single letter is a word in WordNet ("a", "I"), which would make every entry
+# splittable. Two characters is the shortest half worth reporting.
+DEFAULT_MIN_PART_LEN = 2
+
+# Sentence used to ask the live matcher whether a split really is blocked. The
+# surrounding words are inert; only the fused pair matters.
+PROBE_TEMPLATE = "a {left} {right} nearby"
+
+# Entries safe to name outside NVIDIA when illustrating the problem: trademarks
+# and product names, no content-safety terms.
+PUBLIC_EXAMPLES = frozenset({"deskin", "chromebook", "gameboy", "batman", "shotgun", "playstation"})
+
+
+def wordnet_vocabulary(nltk_data_dir: str | None = None) -> Callable[[str], bool]:
+    """Return an `is_word` predicate backed by WordNet.
+
+    The blocklist checkpoint ships its own `nltk_data`; pass that directory to
+    avoid depending on a system-wide corpus.
+    """
+    import nltk
+
+    if nltk_data_dir:
+        nltk.data.path.append(str(nltk_data_dir))
+    from nltk.corpus import wordnet
+
+    wordnet.synsets("test")  # fail here, not part-way through a scan
+    cache: dict[str, bool] = {}
+
+    def is_word(word: str) -> bool:
+        if word not in cache:
+            cache[word] = bool(wordnet.synsets(word))
+        return cache[word]
+
+    return is_word
+
+
+def colliding_splits(
+    entry: str,
+    is_word: Callable[[str], bool],
+    min_part_len: int = DEFAULT_MIN_PART_LEN,
+) -> list[tuple[str, str]]:
+    """Every two-way split of `entry` whose halves are both dictionary words.
+
+    Ordered longest-left-half first, which puts the split prose actually
+    produces ("desk in") ahead of the incidental ones ("de skin").
+    """
+    entry = entry.strip().lower()
+    if " " in entry:
+        return []
+    splits = [
+        (entry[:i], entry[i:])
+        for i in range(min_part_len, len(entry) - min_part_len + 1)
+        if is_word(entry[:i]) and is_word(entry[i:])
+    ]
+    return sorted(splits, key=lambda split: -len(split[0]))
+
+
+def read_keyword_files(directory: str | Path) -> list[str]:
+    """Read every keyword file in a directory, one entry per line."""
+    entries = []
+    for path in sorted(Path(directory).iterdir()):
+        if path.is_dir():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                entries.append(line)
+    return entries
+
+
+def build_reachability_probe(
+    blocklist_words: Iterable[str], whitelist_words: Iterable[str] = ()
+) -> Callable[[str, str], bool]:
+    """Return a predicate telling whether the matcher really blocks a split.
+
+    A split is only a problem if the deployed matcher fires on the spaced form;
+    this drops splits that are theoretical for the list being checked.
+    """
+    from better_profanity.better_profanity import Profanity
+
+    matcher = Profanity()
+    matcher.load_censor_words(custom_words=list(blocklist_words), whitelist_words=list(whitelist_words))
+
+    def is_reachable(left: str, right: str) -> bool:
+        probe = PROBE_TEMPLATE.format(left=left, right=right)
+        return matcher.censor(probe, censor_char="\x00") != probe
+
+    return is_reachable
+
+
+def check_entry(
+    entry: str,
+    is_word: Callable[[str], bool],
+    min_part_len: int = DEFAULT_MIN_PART_LEN,
+    is_reachable: Callable[[str, str], bool] | None = None,
+) -> list[tuple[str, str]]:
+    """Colliding splits for one entry, optionally confirmed against a matcher."""
+    splits = colliding_splits(entry, is_word, min_part_len)
+    if is_reachable is not None:
+        splits = [split for split in splits if is_reachable(*split)]
+    return splits
+
+
+def audit_entries(
+    entries: Iterable[str],
+    is_word: Callable[[str], bool],
+    min_part_len: int = DEFAULT_MIN_PART_LEN,
+    is_reachable: Callable[[str, str], bool] | None = None,
+) -> list[tuple[str, list[tuple[str, str]]]]:
+    """Flagged entries, deduplicated and lowercased, in list order."""
+    findings = []
+    for entry in sorted({e.strip().lower() for e in entries}):
+        splits = check_entry(entry, is_word, min_part_len, is_reachable)
+        if splits:
+            findings.append((entry, splits))
+    return findings
+
+
+def _format_splits(splits: list[tuple[str, str]]) -> str:
+    return ", ".join(f"{left}|{right}" for left, right in splits)
+
+
+def _cmd_gate(args, is_word, is_reachable) -> int:
+    flagged = 0
+    for candidate in args.entry:
+        splits = check_entry(candidate, is_word, args.min_part_len, is_reachable)
+        if not splits:
+            print(f"ok      {candidate}")
+            continue
+        flagged += 1
+        left, right = splits[0]
+        print(f"FLAGGED {candidate}  splits into dictionary words: {_format_splits(splits)}")
+        print(f"        prose such as {PROBE_TEMPLATE.format(left=left, right=right)!r} would be blocked")
+        print(f"        whitelist the phrase '{left} {right}' to exempt that one spelling,")
+        print("        or waive with a note if the split is not English anyone writes")
+    if flagged and not args.warn_only:
+        print(f"\n{flagged} of {len(args.entry)} candidate(s) flagged", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _cmd_audit(args, is_word, is_reachable) -> int:
+    entries = read_keyword_files(args.blocklist_dir)
+    unique = sorted({entry.strip().lower() for entry in entries})
+    single = [entry for entry in unique if " " not in entry]
+    findings = audit_entries(single, is_word, args.min_part_len, is_reachable)
+
+    print(f"blocklist directory       : {args.blocklist_dir}")
+    print(f"entries (lines)           : {len(entries)}")
+    print(f"entries (unique, lowered) : {len(unique)}")
+    print(f"  multi-word              : {len(unique) - len(single)}")
+    print(f"  single-word             : {len(single)}")
+    share = f" ({len(findings) / len(single):.0%} of single-word)" if single else ""
+    print(f"flagged single-word entries: {len(findings)}{share}")
+    if is_reachable is not None:
+        print("  confirmed against the matcher: the spaced form really is blocked")
+
+    public = [(entry, splits) for entry, splits in findings if entry in PUBLIC_EXAMPLES]
+    if public:
+        print("\nexamples that are safe to quote outside NVIDIA:")
+        for entry, splits in public:
+            left, right = splits[0]
+            print(f"  {entry:<14} -> '{left} {right}'")
+        print(f"  ... and {len(findings) - len(public)} more; pass --show-entries to list them")
+
+    if args.show_entries:
+        print("\nall flagged entries:")
+        for entry, splits in findings:
+            print(f"  {entry:<24} {_format_splits(splits)}")
+    return 0
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--nltk-data", help="directory holding the WordNet corpus, e.g. the checkpoint's nltk_data")
+    parser.add_argument(
+        "--min-part-len",
+        type=int,
+        default=DEFAULT_MIN_PART_LEN,
+        help="shortest half that counts as a word (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--confirm-reachable",
+        metavar="BLOCKLIST_DIR",
+        help="keep only splits the matcher built from this directory really blocks",
+    )
+    parser.add_argument("--whitelist-dir", help="whitelist directory, used when confirming reachability")
+
+    sub = parser.add_subparsers(dest="mode", required=True)
+    gate = sub.add_parser("gate", help="check candidate entries before adding them")
+    gate.add_argument("entry", nargs="+")
+    gate.add_argument("--warn-only", action="store_true", help="report flagged candidates but exit 0")
+
+    audit = sub.add_parser("audit", help="report collisions in an existing list")
+    audit.add_argument("blocklist_dir")
+    audit.add_argument("--show-entries", action="store_true", help="print entry text, which may include unsafe terms")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    is_word = wordnet_vocabulary(args.nltk_data)
+
+    source = args.confirm_reachable or (args.blocklist_dir if args.mode == "audit" else None)
+    is_reachable = None
+    if source:
+        whitelist = read_keyword_files(args.whitelist_dir) if args.whitelist_dir else []
+        is_reachable = build_reachability_probe(read_keyword_files(source), whitelist)
+
+    return _cmd_gate(args, is_word, is_reachable) if args.mode == "gate" else _cmd_audit(args, is_word, is_reachable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cosmos_framework/auxiliary/guardrail/blocklist/hygiene_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/hygiene_test.py
@@ -86,3 +86,45 @@ def test_read_keyword_files_skips_blanks_and_comments(tmp_path):
     (tmp_path / "list").write_text("deskin\n\n# a comment\nchromebook\n", encoding="utf-8")
 
     assert read_keyword_files(tmp_path) == ["deskin", "chromebook"]
+
+
+@pytest.mark.L1
+def test_probe_honours_a_whitelisted_phrase():
+    """The remedy this tool prints must be visible to the tool's own probe.
+
+    A whitelist entry that is a phrase never reaches better_profanity; exempting
+    it is something censor_prompt does on top. A probe built on a bare matcher
+    therefore kept reporting "desk in" as reachable after the phrase had been
+    whitelisted -- telling the caller to do something that changed nothing.
+    """
+    without = build_reachability_probe(["deskin"])
+    with_phrase = build_reachability_probe(["deskin"], ["desk in"])
+
+    assert without("desk", "in") is True
+    assert with_phrase("desk", "in") is False
+    # Only that one spelling is exempt; the entry's other splits still fire.
+    assert with_phrase("de", "skin") is True
+
+
+@pytest.mark.L1
+def test_gate_probe_includes_the_candidate_being_gated(tmp_path):
+    """gate checks an entry that is not on the list yet, which is the point.
+
+    Building the probe from the existing list alone means the matcher can never
+    fire on the candidate's own split, so every split is discarded as
+    unreachable and the gate passes anything handed to it.
+    """
+    from cosmos_framework.auxiliary.guardrail.blocklist import hygiene
+
+    blocklist_dir = tmp_path / "custom"
+    blocklist_dir.mkdir()
+    (blocklist_dir / "list").write_text("snow white\n", encoding="utf-8")
+
+    argv = ["--confirm-reachable", str(blocklist_dir), "gate", "deskin"]
+    monkey_vocabulary = hygiene.wordnet_vocabulary
+
+    try:
+        hygiene.wordnet_vocabulary = lambda _dir=None: is_word
+        assert hygiene.main(argv) == 1  # flagged, so non-zero exit
+    finally:
+        hygiene.wordnet_vocabulary = monkey_vocabulary

--- a/cosmos_framework/auxiliary/guardrail/blocklist/hygiene_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/hygiene_test.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+import pytest
+
+from cosmos_framework.auxiliary.guardrail.blocklist.hygiene import (
+    audit_entries,
+    build_reachability_probe,
+    check_entry,
+    colliding_splits,
+    read_keyword_files,
+)
+
+# Stand-in for WordNet so the tests need no corpus download. Only the words the
+# cases below split into are members.
+VOCABULARY = {"de", "desk", "in", "skin", "skinned", "inning", "chrome", "book", "game", "boy", "a"}
+
+
+def is_word(word: str) -> bool:
+    return word in VOCABULARY
+
+
+@pytest.mark.L1
+def test_entry_that_splits_into_two_words_is_flagged():
+    """The reported false positive: "desk" + "in" fuses back into the entry."""
+    assert ("desk", "in") in colliding_splits("deskin", is_word)
+
+
+@pytest.mark.L1
+def test_longest_left_half_is_reported_first():
+    """ "desk in" is the split prose produces; "de skin" is incidental."""
+    splits = colliding_splits("deskin", is_word)
+    assert splits[0] == ("desk", "in")
+    assert ("de", "skin") in splits
+
+
+@pytest.mark.L1
+def test_entry_without_a_dictionary_split_is_not_flagged():
+    assert colliding_splits("huracan", is_word) == []
+
+
+@pytest.mark.L1
+def test_multi_word_entries_are_never_flagged():
+    """A phrase cannot be fused out of prose, so it has no collision shape."""
+    assert colliding_splits("game boy", is_word) == []
+
+
+@pytest.mark.L1
+def test_single_letter_halves_do_not_count():
+    """ "a" is a dictionary word; counting it would flag every entry."""
+    assert colliding_splits("askin", is_word) == []
+
+
+@pytest.mark.L1
+def test_entry_is_lowercased_and_stripped():
+    assert colliding_splits("  DeskIn  ", is_word) == colliding_splits("deskin", is_word)
+
+
+@pytest.mark.L1
+def test_reachability_probe_keeps_only_splits_the_matcher_blocks():
+    """A split is a problem only if the deployed matcher fires on the spaced form."""
+    is_reachable = build_reachability_probe(["deskin"])
+
+    assert is_reachable("desk", "in") is True
+    assert is_reachable("chrome", "book") is False
+
+
+@pytest.mark.L1
+def test_check_entry_drops_splits_that_the_matcher_does_not_block():
+    """ "chromebook" is not on this list, so its split is theoretical here."""
+    is_reachable = build_reachability_probe(["deskin"])
+
+    assert check_entry("deskin", is_word, is_reachable=is_reachable) == [("desk", "in"), ("de", "skin")]
+    assert check_entry("chromebook", is_word, is_reachable=is_reachable) == []
+
+
+@pytest.mark.L1
+def test_audit_deduplicates_case_variants():
+    findings = audit_entries(["deskin", "DeskIn", "huracan"], is_word)
+
+    assert [entry for entry, _ in findings] == ["deskin"]
+
+
+@pytest.mark.L1
+def test_read_keyword_files_skips_blanks_and_comments(tmp_path):
+    (tmp_path / "list").write_text("deskin\n\n# a comment\nchromebook\n", encoding="utf-8")
+
+    assert read_keyword_files(tmp_path) == ["deskin", "chromebook"]


### PR DESCRIPTION
Ordinary prose is blocked when its words fuse into a blocklist entry: "a robot sitting at a desk in the background" matches the entry `deskin`, because `better_profanity` fuses adjacent tokens and tests the fused string. Whitelisting the halves cannot fix it — the fusing does not consult the whitelist, and `desk` and `in` should not be exempt on their own — and the matcher's whitelist only holds single tokens, so a phrase never reaches it.

## What this does

Whitelisted phrases are handled in `censor_prompt`. Matching runs against the whole prompt as before; a match is then dropped only when it falls **entirely inside** an occurrence of a whitelisted phrase. A match that straddles the boundary is kept, so the exemption scopes to exactly the spelling the whitelist names, and every other spelling of the entry stays blocked.

Two helpers make that possible:

- `censored_token_spans` recovers which input tokens each match covered, since the matcher collapses a multi-token match into one censored token;
- `align_folded_to_source` maps folded tokens back to source tokens, because folding an invisible character to a space splits one source token into two.

Phrase occurrences are located **before** invisible characters are folded. That order matters: `desk<U+200B>in` renders as the entry with no space in it, so folding first would turn an evasion into the whitelisted phrase and exempt it. That case stays blocked, and there is a test for it.

## Why not masking, and why not a data fix

The first version of this PR masked the phrase out of the prompt before matching. Review pointed out that removing a span has effects beyond that span, which is correct:

```
entry "in gun", whitelist "desk in", prompt "a desk in gun on the table"
  masking     -> not blocked
  span-based  -> blocked
```

The false positive traces to a single entry, `deskin`, so a data fix was also on the table. Measured:

| approach | clears `desk in` prose | keeps `deskin the animal` | keeps `de skin the animal` | adversarial cost |
|---|---|---|---|---|
| delete the entry | yes | no | no | — |
| move to `exact_match` | yes | yes | **no** | −3 spellings |
| span-based exemption | yes | yes | yes | 0 |

`exact_match` is `\b`-anchored and cannot fuse, and fusing is what catches `de skin` — the same property that causes the false positive. Moving the entry trades one for the other; the exemption keeps both.

## Also in here

- **`hygiene.py`**, a check for entries that ordinary prose fuses into, in `gate` (pre-commit a candidate) and `audit` (report an existing list) modes.
- Two fixes to its reachability probe, both from review: `gate` built the probe from the existing list, so a candidate not yet on it could never fire and the gate passed everything; and the probe ran a bare matcher, so a whitelisted *phrase* was invisible to it and the tool's own advice could not be verified by the tool.
- A load-time warning when a whitelisted word is censored anyway as another entry's leetspeak variant (`flat` is what `fiat` becomes under the i/l mapping). The shipped lists are unaffected; this PR is what makes the whitelist load-bearing.

## Testing

- `blocklist_test.py` + `hygiene_test.py`: 55 passed.
- 1532 adversarial prompts (383 entries × verbatim / spaced / zero-width / fullwidth): 1442 blocked with and without the phrase whitelisted — the change gives up nothing.
- 492-item Cosmos3-Edge reasoner corpus: clears exactly `4_3`, the false positive. No other item changes verdict.

The `to_ascii` reorder that an earlier revision of this branch carried now lives in #193, so the two PRs no longer touch the same code.