### PR TITLE
fix(action): let callers request the action-normalizer forward clamp

### DIFF
--- a/cosmos_framework/data/generator/action/datasets/cosmos3_action_lerobot.py
+++ b/cosmos_framework/data/generator/action/datasets/cosmos3_action_lerobot.py
@@ -319,6 +319,7 @@ class BaseActionLeRobotDataset(Dataset):
         pose_convention: str | None = None,
         rotation_format: str | None = None,
         action_normalization: ActionNormalization | None = None,
+        apply_forward_clamp: bool = False,
         tolerance_s: float = 1e-4,
         max_loaded_datasets: int = _LRU_DATASET_MAX_LOADED,
         skip_video_loading: bool = False,
@@ -352,8 +353,16 @@ class BaseActionLeRobotDataset(Dataset):
             self._rotation_format = rotation_format
             self._action_normalizer: ActionNormalizer | None = None
             if action_normalization is not None:
+                # ``apply_forward_clamp`` decides whether normalized actions are
+                # clamped into [-1, 1]. It matters most on the rot6d diagonal
+                # channels: for DROID, R00/R11 have a q01/q99 half-width of
+                # ~7.7e-4, so they saturate at roughly 3.2 deg of per-frame
+                # rotation and 10 deg/frame normalizes to about -19 unclamped.
+                # Callers name the intent rather than inheriting a default.
                 self._action_normalizer = resolve_action_normalization(
-                    action_normalization, self._load_norm_stats(action_normalization)
+                    action_normalization,
+                    self._load_norm_stats(action_normalization),
+                    apply_forward_clamp=apply_forward_clamp,
                 )
             self._tolerance_s = tolerance_s
             self._max_loaded_datasets = max_loaded_datasets

--- a/cosmos_framework/data/generator/action/datasets/droid_lerobot_dataset.py
+++ b/cosmos_framework/data/generator/action/datasets/droid_lerobot_dataset.py
@@ -99,6 +99,10 @@ class DROIDLeRobotDataset(BaseActionLeRobotDataset):
         enable_fast_init: bool = False,
         max_num_history_actions: int = 0,
         use_image_augmentation: bool = False,
+        # Appended rather than placed next to ``action_normalization``: the
+        # parameters above are positional-or-keyword, so inserting mid-list
+        # would shift every later argument for positional callers.
+        apply_forward_clamp: bool = False,
     ) -> None:
         """ """
         super().__init__(
@@ -113,6 +117,7 @@ class DROIDLeRobotDataset(BaseActionLeRobotDataset):
             pose_convention=pose_convention,
             rotation_format="rot6d",
             action_normalization=action_normalization,
+            apply_forward_clamp=apply_forward_clamp,
             tolerance_s=tolerance_s,
             enable_fast_init=enable_fast_init,
         )


### PR DESCRIPTION
## Summary

#182 made `action_normalization` work for DROID, but built the normalizer with the `apply_forward_clamp=False` default, so the dataset does not clamp into `[-1, 1]`.

The cookbooks did clamp while they normalized by hand (NVIDIA/cosmos#314). NVIDIA/cosmos#317 moved them onto the dataset, and the clamp went away with the hand-written code.

This threads `apply_forward_clamp` through `BaseActionLeRobotDataset` and `DROIDLeRobotDataset` so the caller names the intent, the way #314 did at its construction site:

```python
DROIDMergedLeRobotDataset(
    root=..., action_normalization="quantile_rot", apply_forward_clamp=True,
)
```

## No default behavior change

The default stays `False`, matching `resolve_action_normalization`, so every existing caller keeps its current behavior:

| construction | `forward_clamp` |
|---|---|
| no flag passed | `None` (identical to `main`) |
| `apply_forward_clamp=True` | `(-1.0, 1.0)` |
| `action_normalization=None` | no normalizer |

On `DROIDLeRobotDataset` the parameter is appended rather than placed next to `action_normalization`: that signature is positional-or-keyword, so inserting mid-list would shift `tolerance_s`, `viewpoint`, `use_success_only` and eight more for any positional caller. `BaseActionLeRobotDataset.__init__` is keyword-only, so the placement there is free.

## Why it matters

Measured on the bundled `droid_lerobot_example` — 706 stride-1 windows, 112,960 action scalars — clamped vs unclamped:

| | |
|---|---|
| scalars outside q01/q99 | 1,253 (1.1092%) |
| windows with ≥1 outlier | 155/706 (21.95%) |
| non-overlapping chunks hit | 11/45 (24.4%) |
| max \|unclamped\| | 1.7818 |
| max \|difference\| | 0.78180099 |

87% of those outliers are on the rot6d channels, led by R21 (496) and R20 (336). The gripper never exceeds the range — its q01/q99 is exactly `[0, 1]`. Nothing raises on this path: the values stay plausible floats through the transform, the serving JSON and the model.

The rot6d diagonal channels are the ones with headroom to get much worse. R00/R11 have a q01/q99 half-width of ~7.7e-4, so they saturate at roughly 3.2° of per-frame rotation; at 15 fps, 10°/frame normalizes to about -19 unclamped. This fixture never rotates that fast — its worst case is 1.78 — so that figure is arithmetic from the stats, not a measurement.

## Verification

With `apply_forward_clamp=True` the dataset reproduces #314 exactly on the bundled fixture:

- all **706/706** windows identical, including the **155** where the clamp engages, `max|diff| = 0.0000000000`
- the two normalizers also agree in `offset`, `scale`, `forward_clamp`, `forward_clamp_mask` and type, so they are the same function on every input, not just the measured ones

The first five chunks — the ones the cookbooks use — contain no outliers at all, so a five-chunk comparison is bit-identical either way and cannot distinguish clamped from unclamped.

Existing action tests (43) pass.

## Follow-up

NVIDIA/cosmos will pass the flag from the four DROID forward-dynamics notebooks once this lands; that PR is blocked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)