### PR TITLE
Re-anchor .file_mapping.json on a commit that exists in imaginaire4 main

### DIFF
--- a/.file_mapping.json
+++ b/.file_mapping.json
@@ -1,5 +1,5 @@
 {
-  "_source_commit": "dde4e6ecd882119eed5efc6aa0c63745c29e1a97",
+  "_source_commit": "da723843aa5e9e5f9b16d1d88bc53e61279b5dde",
   "_dest_commit": "088daf42e58a82733e8e0ff5267091b947a962ef",
   "_generated_at": "2026-08-11T05:05:08Z",
   "files": {


### PR DESCRIPTION
_source_commit pointed at dde4e6ecd8, which was only ever reachable from the branch yangyangt/cf-release-source-breaks. Its content did land in i4 main (via 85db463277, verbatim), but the commit itself did not, so nothing in main's history resolves that sha.

That matters because the drift gate and the backport check both reconstruct their baseline as forward(i4 @ _source_commit), reading it with `git show` in an i4 checkout. Against a fresh clone of i4 main -- which is what CI has -- that lookup fails, and with it the entire baseline the two gates compare against.

Re-anchor on da723843aa, the merge-base of that branch and i4 main, so the baseline resolves from main's history alone. The mapping itself is unchanged: same 533 entries, same _dest_commit.