### PR TITLE
fix(inference): resolve local checkpoint dirs to their registered model config

### DIFF
--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -337,6 +337,15 @@ class ConfigFileType(StrEnum):
         raise ValueError(f"Invalid config file: {path}")
 
 
+def _hf_config_has_model_section(config_path: Path) -> bool:
+    """Return whether an HF 'config.json' carries the Cosmos3 'model' section."""
+    try:
+        config_dict = json.loads(config_path.read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(config_dict, dict) and isinstance(config_dict.get("model"), dict)
+
+
 def _hf_repository_from_checkpoint_dir(checkpoint_dir: Path) -> str | None:
     """Recover the Hugging Face repository a local checkpoint directory was published under.
 
@@ -597,41 +606,53 @@ class CheckpointOverrides(ConfigOverrides):
     """Directory for caching S3 checkpoints."""
 
     def _resolve_local_hf_config_file(self, checkpoint_dir: Path, *, checkpoints: dict[str, CheckpointConfig]) -> None:
-        """Point 'config_file' at the registered model config for a local HF checkpoint directory.
+        """Point 'config_file' at the model config for a local HF checkpoint directory.
 
-        The architecture always comes from a registered model config, never from
-        the checkpoint directory's own 'config.json'. Passing a registered name
-        as '--checkpoint-path' already resolves that way (see '_build_checkpoint'),
-        and a local copy of the same repository must not resolve differently just
-        because it was named by path. Checkpoints that are not copies of a
-        registered repository have to name their config explicitly.
+        A copy of a registered repository resolves to that entry's model config,
+        the same one a registered '--checkpoint-path' name resolves to. The two
+        spellings of the same checkpoint must not resolve differently, and the
+        registered config is the authority: a published repository's own
+        'config.json' can be an older snapshot of the architecture
+        (nvidia/Cosmos3-Nano omits 'include_visual' and names the text-only
+        processor) or carry no 'model' section at all (nvidia/Cosmos3-Edge).
+
+        Anything else falls back to the directory's own 'config.json', which is
+        the only description available for a checkpoint we do not publish.
         """
         repository = _hf_repository_from_checkpoint_dir(checkpoint_dir)
         registered = next(
             (checkpoint for checkpoint in checkpoints.values() if checkpoint.hf.repository == repository),
             None,
         )
-        if registered is None:
-            known = ", ".join(sorted(checkpoints)) or "<none>"
-            raise ValueError(
-                f"Could not determine which model config describes checkpoint directory: {checkpoint_dir}. "
-                + (
-                    f"The repository it records ({repository}) is not a registered checkpoint."
-                    if repository is not None
-                    else "It records no source repository to match against a registered checkpoint."
-                )
-                + f" Registered checkpoints: {known}. Pass '--config-file' with the Cosmos3 model config that "
-                f"matches this checkpoint (one of 'cosmos_framework/inference/configs/model/*.yaml'), or pass "
-                f"a registered checkpoint name as '--checkpoint-path'."
+        if registered is not None:
+            # Adopt the registry entry's architecture and load-time settings, but
+            # not its 'hf' download spec: the weights are the local directory.
+            self.config_file = registered.config_file
+            self.model_memory_bytes = registered.model_memory_bytes
+            self.vlm_processor_from_checkpoint = registered.vlm_processor_from_checkpoint
+            for value in reversed(registered.experiment_overrides):
+                if value not in self.experiment_overrides:
+                    self.experiment_overrides.insert(0, value)
+            return
+
+        local_config = checkpoint_dir / "config.json"
+        if _hf_config_has_model_section(local_config):
+            self.config_file = str(local_config)
+            return
+
+        known = ", ".join(sorted(checkpoints)) or "<none>"
+        raise ValueError(
+            f"Could not determine which model config describes checkpoint directory: {checkpoint_dir}. "
+            f"Its 'config.json' has no 'model' section, and "
+            + (
+                f"the repository it records ({repository}) is not a registered checkpoint."
+                if repository is not None
+                else "it records no source repository to match against a registered checkpoint."
             )
-        # Adopt the registry entry's architecture and load-time settings, but not
-        # its 'hf' download spec: the weights are the local directory.
-        self.config_file = registered.config_file
-        self.model_memory_bytes = registered.model_memory_bytes
-        self.vlm_processor_from_checkpoint = registered.vlm_processor_from_checkpoint
-        for value in reversed(registered.experiment_overrides):
-            if value not in self.experiment_overrides:
-                self.experiment_overrides.insert(0, value)
+            + f" Registered checkpoints: {known}. Pass '--config-file' with the Cosmos3 model config that "
+            f"matches this checkpoint (one of 'cosmos_framework/inference/configs/model/*.yaml'), or pass "
+            f"a registered checkpoint name as '--checkpoint-path'."
+        )
 
     def _build_checkpoint(self, checkpoints: dict[str, CheckpointConfig]):
         # Detect checkpoint type

--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -337,6 +337,36 @@ class ConfigFileType(StrEnum):
         raise ValueError(f"Invalid config file: {path}")
 
 
+def _hf_repository_from_checkpoint_dir(checkpoint_dir: Path) -> str | None:
+    """Recover the Hugging Face repository a local checkpoint directory was published under.
+
+    'convert_model_to_diffusers' stamps every component in
+    'modular_model_index.json' with the source repo id. Unlike the directory
+    name it survives a copy or rename, so it is the only dependable way to map a
+    downloaded checkpoint directory back onto its registry entry.
+
+    Returns None when the file is absent, unreadable, or does not agree on a
+    single repository.
+    """
+    try:
+        index = json.loads((checkpoint_dir / "modular_model_index.json").read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(index, dict):
+        return None
+    repositories = {
+        component[2]["pretrained_model_name_or_path"]
+        for component in index.values()
+        if isinstance(component, list)
+        and len(component) == 3
+        and isinstance(component[2], dict)
+        and isinstance(component[2].get("pretrained_model_name_or_path"), str)
+    }
+    if len(repositories) != 1:
+        return None
+    return repositories.pop()
+
+
 def _validate_config_file(v: str) -> str:
     config_file_type = ConfigFileType.from_path(v)
     if config_file_type == ConfigFileType.MODULE:
@@ -383,6 +413,18 @@ class ConfigArgs(ArgsBase):
                 return unstructure_config(self.load_config().model)
             case ConfigFileType.YAML | ConfigFileType.JSON:
                 config_dict = deserialize_config_dict(Path(self.config_file))
+                # Check for 'model' before merging: 'experiment_overrides' are
+                # dotlists rooted at 'model.', so merging first synthesizes a
+                # 'model' section out of the overrides alone. That defeats the
+                # guard in 'load_model_config_from_hf_config' and turns a
+                # missing architecture into a much later, opaque failure deep in
+                # model construction (e.g. omegaconf "Missing key ema").
+                if "model" not in config_dict:
+                    raise KeyError(
+                        f"Config file has no 'model' section, so it does not describe a Cosmos3 model "
+                        f"architecture: {self.config_file}. Pass '--config-file' with a Cosmos3 model config "
+                        f"(e.g. one of 'cosmos_framework/inference/configs/model/*.yaml')."
+                    )
                 overrides_omegaconf = OmegaConf.from_dotlist(self.experiment_overrides)
                 config_dict = OmegaConf.to_container(OmegaConf.merge(config_dict, overrides_omegaconf), resolve=False)
                 assert isinstance(config_dict, dict)
@@ -554,6 +596,43 @@ class CheckpointOverrides(ConfigOverrides):
     checkpoint_cache_dir: Training[Path | None] = None
     """Directory for caching S3 checkpoints."""
 
+    def _resolve_local_hf_config_file(self, checkpoint_dir: Path, *, checkpoints: dict[str, CheckpointConfig]) -> None:
+        """Point 'config_file' at the registered model config for a local HF checkpoint directory.
+
+        The architecture always comes from a registered model config, never from
+        the checkpoint directory's own 'config.json'. Passing a registered name
+        as '--checkpoint-path' already resolves that way (see '_build_checkpoint'),
+        and a local copy of the same repository must not resolve differently just
+        because it was named by path. Checkpoints that are not copies of a
+        registered repository have to name their config explicitly.
+        """
+        repository = _hf_repository_from_checkpoint_dir(checkpoint_dir)
+        registered = next(
+            (checkpoint for checkpoint in checkpoints.values() if checkpoint.hf.repository == repository),
+            None,
+        )
+        if registered is None:
+            known = ", ".join(sorted(checkpoints)) or "<none>"
+            raise ValueError(
+                f"Could not determine which model config describes checkpoint directory: {checkpoint_dir}. "
+                + (
+                    f"The repository it records ({repository}) is not a registered checkpoint."
+                    if repository is not None
+                    else "It records no source repository to match against a registered checkpoint."
+                )
+                + f" Registered checkpoints: {known}. Pass '--config-file' with the Cosmos3 model config that "
+                f"matches this checkpoint (one of 'cosmos_framework/inference/configs/model/*.yaml'), or pass "
+                f"a registered checkpoint name as '--checkpoint-path'."
+            )
+        # Adopt the registry entry's architecture and load-time settings, but not
+        # its 'hf' download spec: the weights are the local directory.
+        self.config_file = registered.config_file
+        self.model_memory_bytes = registered.model_memory_bytes
+        self.vlm_processor_from_checkpoint = registered.vlm_processor_from_checkpoint
+        for value in reversed(registered.experiment_overrides):
+            if value not in self.experiment_overrides:
+                self.experiment_overrides.insert(0, value)
+
     def _build_checkpoint(self, checkpoints: dict[str, CheckpointConfig]):
         # Detect checkpoint type
         if self.checkpoint_path in checkpoints:
@@ -582,17 +661,13 @@ class CheckpointOverrides(ConfigOverrides):
                 checkpoint_dir = checkpoint_dir / "model"
             self.checkpoint_path = str(checkpoint_dir)
             self.checkpoint_type = CheckpointType.from_path(checkpoint_dir)
-            # Local HF dir with no explicit --config-file: fall back to the
-            # dir's own config.json (mirrors the registry branch and
-            # from_pretrained_dcp). Without this, config_file stays at the
-            # default .py module, which needs a Hydra experiment that a local
-            # HF dir cannot supply -> MissingConfigException("experiment/").
-            if (
-                self.checkpoint_type == CheckpointType.HF
-                and self.config_file == DEFAULT_CONFIG_FILE
-                and (checkpoint_dir / "config.json").is_file()
-            ):
-                self.config_file = str(checkpoint_dir / "config.json")
+            # Local HF dir with no explicit --config-file: resolve the same
+            # registered model config the registry branch above would use. Left
+            # alone, config_file stays at the default .py module, which needs a
+            # Hydra experiment that a local HF dir cannot supply ->
+            # MissingConfigException("experiment/").
+            if self.checkpoint_type == CheckpointType.HF and self.config_file == DEFAULT_CONFIG_FILE:
+                self._resolve_local_hf_config_file(checkpoint_dir, checkpoints=checkpoints)
         self.config_file_type = ConfigFileType.from_path(self.config_file)
 
         if self.checkpoint_type == CheckpointType.DCP and self.config_file_type == ConfigFileType.MODULE:

--- a/cosmos_framework/inference/common/args_test.py
+++ b/cosmos_framework/inference/common/args_test.py
@@ -216,18 +216,42 @@ def test_local_checkpoint_without_architecture_raises(tmp_path: Path):
         )
 
 
-def test_local_checkpoint_config_json_never_supplies_the_architecture(tmp_path: Path):
-    """A directory's own 'config.json' is not an architecture source.
+def test_registered_repository_wins_over_the_directory_config(tmp_path: Path):
+    """A registered repository's config wins over the copy's own 'config.json'.
 
-    A registered name and a local copy of the same repository must resolve to the
-    same model config, so a self-describing 'config.json' must not divert that.
+    A published repo's 'config.json' can be an older snapshot of the architecture
+    than the registered config: nvidia/Cosmos3-Nano omits 'include_visual' and
+    names the text-only processor, which made a local copy load a text-only
+    Reasoner. The registered name and a local copy must resolve identically.
+    """
+    checkpoints = OmniSetupOverrides.CHECKPOINTS
+    nano = checkpoints["Cosmos3-Nano"]
+    checkpoint_dir = write_local_hf_checkpoint(
+        tmp_path / "snapshot", config={"model": MODEL_SECTION}, repo_id=nano.hf.repository
+    )
+
+    args = CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(checkpoints=checkpoints)
+
+    assert args.config_file == nano.config_file
+    vlm_config = args.load_model_config_dict()["config"]["vlm_config"]
+    assert vlm_config["model_instance"]["config"]["include_visual"] is True
+    assert vlm_config["tokenizer"]["_target_"].endswith("build_processor_lazy")
+
+
+def test_unregistered_local_checkpoint_uses_its_own_config(tmp_path: Path):
+    """A checkpoint we do not publish keeps describing itself.
+
+    Its own 'config.json' is the only description available, so it must keep
+    working without '--config-file' (e.g. the ModelOpt FP8 Nano checkpoint, which
+    ships from a subdirectory of an unregistered repository).
     """
     checkpoint_dir = write_local_hf_checkpoint(tmp_path / "self-described", config={"model": MODEL_SECTION})
 
-    with pytest.raises(ValueError, match="Could not determine which model config"):
-        CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(
-            checkpoints=OmniSetupOverrides.CHECKPOINTS
-        )
+    args = CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(
+        checkpoints=OmniSetupOverrides.CHECKPOINTS
+    )
+
+    assert args.config_file == str(checkpoint_dir / "config.json")
 
 
 def test_explicit_config_file_bypasses_resolution(tmp_path: Path):

--- a/cosmos_framework/inference/common/args_test.py
+++ b/cosmos_framework/inference/common/args_test.py
@@ -8,11 +8,50 @@ from pathlib import Path
 import pytest
 
 from cosmos_framework.inference.args import DEFAULT_CHECKPOINT, DEFAULT_CHECKPOINT_NAME, OmniSetupOverrides
-from cosmos_framework.inference.common.args import CheckpointConfig, CheckpointOverrides, CheckpointType, download_file
+from cosmos_framework.inference.common.args import (
+    CheckpointConfig,
+    CheckpointOverrides,
+    CheckpointType,
+    ConfigArgs,
+    ConfigFileType,
+    download_file,
+)
+from cosmos_framework.inference.common.config import deserialize_config_dict
 
 CHECKPOINTS: dict[str, CheckpointConfig] = {
     DEFAULT_CHECKPOINT_NAME: DEFAULT_CHECKPOINT,
 }
+
+# Enough of a Cosmos3 'model' section for config resolution; not a loadable architecture.
+MODEL_SECTION = {"_target": "omni_mot_model", "config": {"_type": "omni_mot_model_config"}}
+
+
+def write_local_hf_checkpoint(root: Path, *, config: dict, repo_id: str | None = None) -> Path:
+    """Write a minimal local Hugging Face checkpoint directory."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (root / "model.safetensors").touch()
+    if repo_id is not None:
+        # Mirrors the layout '_write_modular_model_index' emits.
+        (root / "modular_model_index.json").write_text(
+            json.dumps(
+                {
+                    "_class_name": "Cosmos3OmniModularPipeline",
+                    "transformer": [
+                        "diffusers",
+                        "Cosmos3OmniTransformer",
+                        {
+                            "pretrained_model_name_or_path": repo_id,
+                            "subfolder": "transformer",
+                            "type_hint": ["diffusers", "Cosmos3OmniTransformer"],
+                            "variant": None,
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    return root
 
 
 def test_num_iterations_requires_benchmark() -> None:
@@ -100,16 +139,16 @@ def test_parse_checkpoint_path(tmp_path: Path):
     assert args.checkpoint_type == "hf"
     assert args.experiment == ""
 
-    # Local HF checkpoint
-    hf_path = tmp_path / "hf"
-    hf_path.mkdir(parents=True, exist_ok=True)
-    (hf_path / "config.json").touch()
-    (hf_path / "model.safetensors").touch()
+    # Local HF checkpoint: a copy of the registered repo resolves to its config.
+    hf_path = write_local_hf_checkpoint(
+        tmp_path / "hf", config={"model": MODEL_SECTION}, repo_id=DEFAULT_CHECKPOINT.hf.repository
+    )
     args = CheckpointOverrides(
         checkpoint_path=str(hf_path),
     ).build_checkpoint(checkpoints=CHECKPOINTS)
     assert args.checkpoint_type == "hf"
     assert args.experiment == ""
+    assert args.config_file == DEFAULT_CHECKPOINT.config_file
 
     # Local DCP checkpoint
     dcp_path = (
@@ -138,3 +177,109 @@ def test_parse_checkpoint_path(tmp_path: Path):
         == "t2i_mot_exp000_015_qwen3_0p6b_256res_frozen_llm_lr_4e4_large_seq_no_llm_qknorm_gcp_bs8k_baseline_long_run_1e4"
     )
     assert args.config_file == "cosmos_framework/configs/base/config.py"
+
+
+def test_local_edge_checkpoint_resolves_registry_config(tmp_path: Path):
+    """A local copy of nvidia/Cosmos3-Edge gets its architecture from the registry.
+
+    The published Edge repo's top-level config.json is the reasoner HF config and
+    carries no 'model' section, so the architecture is recovered from the repo id
+    the checkpoint records for itself rather than from the directory.
+    """
+    checkpoints = OmniSetupOverrides.CHECKPOINTS
+    edge = checkpoints["Cosmos3-Edge"]
+    # A renamed copy: the directory name must not be what makes this work.
+    checkpoint_dir = write_local_hf_checkpoint(
+        tmp_path / "Cosmos-Edge",
+        config={"architectures": ["Cosmos3EdgeForConditionalGeneration"], "model_type": "cosmos3_edge"},
+        repo_id=edge.hf.repository,
+    )
+
+    args = CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(checkpoints=checkpoints)
+
+    assert args.checkpoint_type == "hf"
+    assert args.config_file == edge.config_file
+    assert args.model_memory_bytes == edge.model_memory_bytes
+    # The weights still come from the local directory, not a hub download.
+    assert args.checkpoint_path == str(checkpoint_dir)
+    # The resolved config really does describe the architecture.
+    assert "ema" in args.load_model_config_dict()["config"]
+
+
+def test_local_checkpoint_without_architecture_raises(tmp_path: Path):
+    """An unidentifiable local HF dir fails fast instead of building a bogus config."""
+    checkpoint_dir = write_local_hf_checkpoint(tmp_path / "mystery", config={"model_type": "cosmos3_edge"})
+
+    with pytest.raises(ValueError, match="records no source repository"):
+        CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(
+            checkpoints=OmniSetupOverrides.CHECKPOINTS
+        )
+
+
+def test_local_checkpoint_config_json_never_supplies_the_architecture(tmp_path: Path):
+    """A directory's own 'config.json' is not an architecture source.
+
+    A registered name and a local copy of the same repository must resolve to the
+    same model config, so a self-describing 'config.json' must not divert that.
+    """
+    checkpoint_dir = write_local_hf_checkpoint(tmp_path / "self-described", config={"model": MODEL_SECTION})
+
+    with pytest.raises(ValueError, match="Could not determine which model config"):
+        CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(
+            checkpoints=OmniSetupOverrides.CHECKPOINTS
+        )
+
+
+def test_explicit_config_file_bypasses_resolution(tmp_path: Path):
+    """An explicit '--config-file' is honoured for any local directory."""
+    checkpoint_dir = write_local_hf_checkpoint(tmp_path / "self-described", config={"model": MODEL_SECTION})
+    edge_config = OmniSetupOverrides.CHECKPOINTS["Cosmos3-Edge"].config_file
+
+    args = CheckpointOverrides(checkpoint_path=str(checkpoint_dir), config_file=edge_config).build_checkpoint(
+        checkpoints=OmniSetupOverrides.CHECKPOINTS
+    )
+
+    assert args.config_file == edge_config
+    assert args.checkpoint_path == str(checkpoint_dir)
+
+
+def test_local_checkpoint_with_unregistered_repository_raises(tmp_path: Path):
+    """An unknown source repository is named, and an empty registry still reads cleanly.
+
+    'export_model' / 'export_train_config' pass an empty registry, so the message
+    must not degrade into an empty list there.
+    """
+    checkpoint_dir = write_local_hf_checkpoint(
+        tmp_path / "unknown", config={"model_type": "cosmos3_edge"}, repo_id="acme/Not-Registered"
+    )
+
+    with pytest.raises(ValueError, match=r"acme/Not-Registered.*Registered checkpoints: <none>"):
+        CheckpointOverrides(checkpoint_path=str(checkpoint_dir)).build_checkpoint(checkpoints={})
+
+
+def test_load_model_config_dict_requires_model_section(tmp_path: Path):
+    """'experiment_overrides' must not be able to synthesize a 'model' section.
+
+    The overrides are dotlists rooted at 'model.'. Merging them into a config
+    without a 'model' section used to produce a two-key stub that only failed
+    much later, deep in model construction, as 'Missing key ema'.
+    """
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"model_type": "cosmos3_edge"}), encoding="utf-8")
+    args = ConfigArgs(
+        config_file=str(config_path),
+        config_file_type=ConfigFileType.JSON,
+        experiment="",
+        experiment_overrides=["model.config.vlm_config.pretrained_weights.enabled=False"],
+    )
+
+    with pytest.raises(KeyError, match="no 'model' section"):
+        args.load_model_config_dict()
+
+
+def test_registry_model_configs_describe_an_architecture():
+    """Every registered checkpoint's config file carries a usable 'model' section."""
+    for name, checkpoint in OmniSetupOverrides.CHECKPOINTS.items():
+        config_dict = deserialize_config_dict(Path(checkpoint.config_file))
+        assert "model" in config_dict, f"{name}: {checkpoint.config_file} has no 'model' section"
+        assert "ema" in config_dict["model"]["config"], f"{name}: {checkpoint.config_file} has no 'model.config.ema'"

--- a/cosmos_framework/scripts/_test/convert_model_to_dcp.sh
+++ b/cosmos_framework/scripts/_test/convert_model_to_dcp.sh
@@ -17,12 +17,8 @@ CUDA_VISIBLE_DEVICES= python -m cosmos_framework.scripts.export_model \
     --no-use-ema-weights
 
 # HF Inference
-# The architecture always comes from a registered model config. This directory is
-# an export_model output rather than a copy of a registered repository, so it has
-# to name that config explicitly.
 torchrun $TORCHRUN_ARGS -m cosmos_framework.scripts.inference \
     -i "$INPUT_DIR/omni/t2i.json" \
     -o $OUTPUT_DIR/inference \
     --checkpoint-path $TMP_DIR/model \
-    --config-file cosmos_framework/inference/configs/model/Cosmos3-Nano.yaml \
     $INFERENCE_ARGS

--- a/cosmos_framework/scripts/_test/convert_model_to_dcp.sh
+++ b/cosmos_framework/scripts/_test/convert_model_to_dcp.sh
@@ -17,8 +17,12 @@ CUDA_VISIBLE_DEVICES= python -m cosmos_framework.scripts.export_model \
     --no-use-ema-weights
 
 # HF Inference
+# The architecture always comes from a registered model config. This directory is
+# an export_model output rather than a copy of a registered repository, so it has
+# to name that config explicitly.
 torchrun $TORCHRUN_ARGS -m cosmos_framework.scripts.inference \
     -i "$INPUT_DIR/omni/t2i.json" \
     -o $OUTPUT_DIR/inference \
     --checkpoint-path $TMP_DIR/model \
+    --config-file cosmos_framework/inference/configs/model/Cosmos3-Nano.yaml \
     $INFERENCE_ARGS


### PR DESCRIPTION
Fixes #191. Fixes #158.

## Problem

`--checkpoint-path <local dir>` took the model architecture from the directory's own `config.json`. For our published repositories that file is not a faithful description of the architecture, and the two issues are the two ways it goes wrong.

**#191 — `nvidia/Cosmos3-Edge`.** Published in the diffusers layout, where the top-level `config.json` is the reasoner config (`Cosmos3EdgeForConditionalGeneration`) and carries **no `model` section**.

It did not fail there. `ConfigArgs.load_model_config_dict` merges `experiment_overrides` *before* checking for `model`, and those overrides are dotlists rooted at `model.`:

```
model.config.vlm_config.pretrained_weights.enabled=False
model.config.diffusion_expert_config.load_weights_from_pretrained=False
```

The merge synthesised a `model` section out of the overrides alone, defeating the guard in `load_model_config_from_hf_config` and yielding a two-key stub, which only failed much later inside model construction:

```
omegaconf.errors.ConfigAttributeError: Missing key ema
    full_key: config.ema
    object_type=dict
```

**#158 — `nvidia/Cosmos3-Nano`.** Here the `model` section exists but is an older snapshot of the architecture than the registered config:

| | snapshot `config.json` | registered `Cosmos3-Nano.yaml` |
|---|---|---|
| `include_visual` | absent → `False` | `true` |
| `vlm_config.tokenizer` | `create_qwen2_tokenizer_with_download` → `LLMTokenizerProcessor` | `build_processor_lazy` → `Qwen3VLProcessor` |

Hence `checkpoint's reasoner LM has no visual tower` and, once forced on, `LLMTokenizerProcessor does not implement apply_chat_template`.

## Change

Resolution order for a local HF directory given without `--config-file`:

| | Architecture source |
|---|---|
| 1. A copy of a **registered** repository | That entry's model config — the same one the registered name resolves to |
| 2. Otherwise, directory has its own `model` section | That `config.json` — unchanged behaviour |
| 3. Neither | Error naming the registered checkpoints and asking for `--config-file` |

Registered names and explicit `--config-file` are untouched.

Rule 1 is the fix. The two spellings of one checkpoint must not resolve differently, and for a checkpoint we publish, the registered config is the authority. After this change they agree — 10 of 12 resolved fields are identical, and the two that differ are the ones that should:

```
DIFF checkpoint_hf:    by-name: {repository: nvidia/Cosmos3-Edge, revision: main, ...}
                       by-path: None                       # read from disk, not downloaded
DIFF checkpoint_path:  by-name: 'Cosmos3-Edge'
                       by-path: '/.../Cosmos-Edge'

resolved model config IDENTICAL: True
```

Rule 2 keeps every checkpoint we do *not* publish working exactly as before, without `--config-file`: a ModelOpt FP8 build, an `export_model` output, a fine-tune. Its own `config.json` is the only description available for those.

The repository in rule 1 is recovered from the `pretrained_model_name_or_path` that `convert_model_to_diffusers` stamps into `modular_model_index.json`, matched exactly against the registry. That survives a copy or rename, which matters here — #191's directory was named `Cosmos-Edge`, not `Cosmos3-Edge`, so directory-name matching would not work. All seven registered repositories were checked on `main`: every component agrees on one repository id, and each matches its registry entry exactly.

Also checks for `model` before merging the overrides, so a config file that does not describe an architecture fails with that message instead of an opaque error deep in model construction.

This lives in `CheckpointOverrides._build_checkpoint`, so it applies to every entry point taking `--checkpoint-path` — `convert_model_to_dcp`, `convert_model_to_diffusers`, `convert_model_to_vlm_safetensors`, `inference`, `inference2` — not just the script in #191.

## Limits

**#158 is fixed only for Nano/Super revisions from 2026-07-09 onward.** `modular_model_index.json` was added to those repositories in *Add modular pipeline index*; three earlier revisions do not have it, so a copy pinned to one of those is not recognised and falls back to rule 2 — i.e. it keeps the reported behaviour. #158's reported revision `411f42a` is the commit that introduced the file, so that case is fixed. Every published `nvidia/Cosmos3-Edge` revision has it. A download that filters the file out (`hf download --include ...`) is likewise unrecognised.

Misidentification needs a checkpoint to record one of the seven registered repositories as its own source while not being that model — e.g. running `convert_model_to_diffusers --repo-id nvidia/Cosmos3-Nano` over a fine-tune that changed the architecture. `repo_id` otherwise defaults to the output directory name, which carries no `nvidia/` prefix and cannot match.

## Verification

Run on a GB200 login host.

**#191** — a real `nvidia/Cosmos3-Edge` snapshot copied into a plain directory renamed `Cosmos-Edge`, `config.json` untouched.

Before, the reported command reproduces exactly:
```
omegaconf.errors.ConfigAttributeError: Missing key ema
    full_key: config.ema
    object_type=dict
```

After, the same command, still no `--config-file`:
```
Saved checkpoint to .../issue191_final_out
=== FINAL EXIT 0 ===
  model/.metadata  model/config.json  model/__0_0.distcp  model/__0_1.distcp
```

**#158** — the `config.json` and `modular_model_index.json` published at the reported revision `411f42a`, over a local `nvidia/Cosmos3-Nano` copy:

```
[the snapshot's own config.json — what #158 hits]
   include_visual: <absent>
   tokenizer     : create_qwen2_tokenizer_with_download

[after the fix — resolved from Cosmos3-Nano.yaml]
   include_visual: True
   tokenizer     : cosmos_framework.data.generator.processors.build_processor_lazy

model config IDENTICAL to '--checkpoint-path Cosmos3-Nano': True
weights still local: True | checkpoint_hf: None
```

This is config resolution, not a Reasoner inference run: the resolved config is identical to what `--checkpoint-path Cosmos3-Nano` produces, which #158 reports as working.

**Rule 2, against a real `export_model` output** (the shape `training-smoke` and the FP8 smoke test use):
```
dir has modular_model_index.json: False
dir config.json has 'model'    : True
resolved config_file: .../exported/config.json   # its own, as before
```

**Unit tests** — `cosmos_framework/inference/common/args_test.py`, 12 passed, covering: a renamed copy resolving to the registry config; a registered repository's config winning over the copy's own `config.json`; an unregistered self-describing directory keeping its own; an explicit `--config-file` bypassing resolution; unidentifiable directories; the empty-registry message (`export_model` / `export_train_config` pass `checkpoints={}`); and the overrides no longer synthesising a `model` section.

## Not included

The Edge branch of `convert_model_to_diffusers` returns before the "Add top-level config" block, which is why exported Edge repos lack the `model` section in the first place. Making that branch write it is a separate change — I could not verify it end to end, as the Edge DCP checkpoint available to me predates `diffusion_expert_config.enable_vision_modality_embeddings` and no longer loads on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
