### PR TITLE
feat(guardrail): measure what a blocklist change stops catching

### DIFF
--- a/cosmos_framework/auxiliary/guardrail/blocklist/coverage.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/coverage.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""Measure what a blocklist change stops catching.
+
+A corpus of ordinary model output answers one question: does a change block
+things it did not block before. Any change that *unblocks* -- a whitelist entry,
+a data move, a new exemption mechanism -- carries the opposite risk, and a
+corpus cannot show it: the phrasings that would newly slip through are exactly
+the ones ordinary output does not contain.
+
+This builds that missing side. For every entry it writes four prompts, one per
+way the entry can be spelled while still reading as itself:
+
+    verbatim    the entry as written
+    spaced      split in the middle, the fusing evasion ("de skin")
+    invisible   split with a zero-width space
+    fullwidth   spelled in fullwidth letters
+
+Run it before and after a change and compare: any prompt that was blocked and
+now is not is a spelling the change gave up. Entry text is never printed --
+results are keyed by index and spelling -- so output can be pasted into a
+review.
+
+    coverage.py <blocklist-dir> --whitelist-dir <dir> --json before.json
+    coverage.py <blocklist-dir> --whitelist-dir <dir> --add-phrase "desk in" --json after.json
+    coverage.py --compare before.json after.json
+"""
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+# Lowercase ASCII letter -> its fullwidth presentation form.
+FULLWIDTH = {chr(code): chr(code - 0x61 + 0xFF41) for code in range(0x61, 0x7B)}
+
+ZERO_WIDTH_SPACE = "​"
+
+PROMPT_TEMPLATE = "a photo of {body} in the scene"
+
+
+def spellings(entry: str) -> dict[str, str]:
+    """The four prompts probing one entry.
+
+    Splitting at the midpoint is arbitrary but stable: the point is to produce a
+    spelling the matcher has to fuse back together, not to find the split a
+    person would choose.
+    """
+    entry = entry.strip()
+    middle = max(1, len(entry) // 2)
+    return {
+        "verbatim": PROMPT_TEMPLATE.format(body=entry),
+        "spaced": PROMPT_TEMPLATE.format(body=f"{entry[:middle]} {entry[middle:]}"),
+        "invisible": PROMPT_TEMPLATE.format(body=f"{entry[:middle]}{ZERO_WIDTH_SPACE}{entry[middle:]}"),
+        "fullwidth": PROMPT_TEMPLATE.format(body="".join(FULLWIDTH.get(c, c) for c in entry)),
+    }
+
+
+def measure(entries: Iterable[str], is_blocked: Callable[[str], bool]) -> dict[str, bool]:
+    """Whether each probe prompt is blocked, keyed "<index>:<spelling>"."""
+    results: dict[str, bool] = {}
+    for index, entry in enumerate(entries):
+        for spelling, prompt in spellings(entry).items():
+            results[f"{index}:{spelling}"] = bool(is_blocked(prompt))
+    return results
+
+
+def summarize(results: dict[str, bool]) -> dict[str, dict[str, int]]:
+    """Blocked / passed counts per spelling, plus a total."""
+    summary: dict[str, dict[str, int]] = {}
+    for key, blocked in results.items():
+        bucket = summary.setdefault(key.split(":", 1)[1], {"blocked": 0, "passed": 0})
+        bucket["blocked" if blocked else "passed"] += 1
+    summary["total"] = {
+        "blocked": sum(1 for v in results.values() if v),
+        "passed": sum(1 for v in results.values() if not v),
+    }
+    return summary
+
+
+def compare(before: dict[str, bool], after: dict[str, bool]) -> dict[str, list[str]]:
+    """What the change gave up, and what it started catching.
+
+    `lost` is the one that matters for an unblocking change: prompts that were
+    blocked and are not any more.
+    """
+    shared = set(before) & set(after)
+    return {
+        "lost": sorted(key for key in shared if before[key] and not after[key]),
+        "gained": sorted(key for key in shared if not before[key] and after[key]),
+        "only_in_before": sorted(set(before) - set(after)),
+        "only_in_after": sorted(set(after) - set(before)),
+    }
+
+
+def _build_is_blocked(blocklist_dir: str, whitelist_dir: str | None, add_phrase: str | None):
+    """A predicate running the deployed censor path over the given lists."""
+    from better_profanity.better_profanity import Profanity
+
+    from cosmos_framework.auxiliary.guardrail.blocklist.blocklist import Blocklist
+    from cosmos_framework.auxiliary.guardrail.blocklist.utils import read_keyword_list_from_dir
+
+    entries = read_keyword_list_from_dir(blocklist_dir)
+    whitelist = read_keyword_list_from_dir(whitelist_dir) if whitelist_dir else []
+    if add_phrase:
+        whitelist = whitelist + [add_phrase]
+
+    probe = Blocklist.__new__(Blocklist)
+    probe.profanity = Profanity()
+    probe.profanity.load_censor_words(
+        custom_words=entries,
+        whitelist_words=[w for w in whitelist if " " not in w.strip()],
+    )
+    probe.whitelist_words = whitelist
+    probe.whitelist_phrases = sorted((w for w in whitelist if " " in w.strip()), key=len, reverse=True)
+    return entries, (lambda text: probe.censor_prompt(text)[0])
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("blocklist_dir", nargs="?", help="directory of blocklist keyword files")
+    parser.add_argument("--whitelist-dir", help="directory of whitelist keyword files")
+    parser.add_argument("--add-phrase", help="whitelist this phrase in addition, to model a proposed change")
+    parser.add_argument("--json", help="write the per-prompt results here")
+    parser.add_argument("--compare", nargs=2, metavar=("BEFORE", "AFTER"), help="diff two result files")
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+
+    if args.compare:
+        before = json.loads(Path(args.compare[0]).read_text())["results"]
+        after = json.loads(Path(args.compare[1]).read_text())["results"]
+        diff = compare(before, after)
+        print(f"lost   (blocked before, not after): {len(diff['lost'])}")
+        for key in diff["lost"]:
+            print(f"   {key}")
+        print(f"gained (not blocked before, now)  : {len(diff['gained'])}")
+        return 1 if diff["lost"] else 0
+
+    if not args.blocklist_dir:
+        print("a blocklist directory is required unless --compare is used", file=sys.stderr)
+        return 2
+
+    entries, is_blocked = _build_is_blocked(args.blocklist_dir, args.whitelist_dir, args.add_phrase)
+    results = measure(entries, is_blocked)
+    summary = summarize(results)
+    print(f"entries: {len(entries)}   prompts: {len(results)}")
+    for spelling in ("verbatim", "spaced", "invisible", "fullwidth", "total"):
+        if spelling in summary:
+            counts = summary[spelling]
+            print(f"  {spelling:10s} blocked={counts['blocked']:5d} passed={counts['passed']:5d}")
+    if args.json:
+        Path(args.json).write_text(json.dumps({"summary": summary, "results": results}, indent=0))
+        print(f"written: {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cosmos_framework/auxiliary/guardrail/blocklist/coverage_test.py
+++ b/cosmos_framework/auxiliary/guardrail/blocklist/coverage_test.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+import json
+
+import pytest
+
+from cosmos_framework.auxiliary.guardrail.blocklist.coverage import (
+    ZERO_WIDTH_SPACE,
+    compare,
+    main,
+    measure,
+    spellings,
+    summarize,
+)
+
+
+@pytest.mark.L1
+def test_spellings_cover_the_four_evasions():
+    """Each probe must still read as the entry to a person."""
+    probes = spellings("deskin")
+
+    assert probes["verbatim"] == "a photo of deskin in the scene"
+    assert probes["spaced"] == "a photo of des kin in the scene"
+    assert probes["invisible"] == f"a photo of des{ZERO_WIDTH_SPACE}kin in the scene"
+    assert probes["fullwidth"] == "a photo of ｄｅｓｋｉｎ in the scene"
+
+
+@pytest.mark.L1
+def test_spellings_handle_a_short_entry():
+    """A two-character entry must still produce a split, not an empty half."""
+    probes = spellings("ab")
+
+    assert probes["spaced"] == "a photo of a b in the scene"
+
+
+@pytest.mark.L1
+def test_measure_keys_results_by_index_and_spelling():
+    """Entry text never appears in the results, so they are safe to paste."""
+    results = measure(["deskin", "chromebook"], lambda text: "deskin" in text)
+
+    assert results["0:verbatim"] is True
+    assert results["1:verbatim"] is False
+    assert all(":" in key for key in results)
+    assert not any("deskin" in key for key in results)
+
+
+@pytest.mark.L1
+def test_summarize_counts_per_spelling():
+    results = {"0:verbatim": True, "0:spaced": False, "1:verbatim": True, "1:spaced": True}
+
+    summary = summarize(results)
+
+    assert summary["verbatim"] == {"blocked": 2, "passed": 0}
+    assert summary["spaced"] == {"blocked": 1, "passed": 1}
+    assert summary["total"] == {"blocked": 3, "passed": 1}
+
+
+@pytest.mark.L1
+def test_compare_names_what_a_change_gave_up():
+    """`lost` is the answer an unblocking change has to provide."""
+    before = {"0:verbatim": True, "0:spaced": True, "1:verbatim": False}
+    after = {"0:verbatim": True, "0:spaced": False, "1:verbatim": True}
+
+    diff = compare(before, after)
+
+    assert diff["lost"] == ["0:spaced"]
+    assert diff["gained"] == ["1:verbatim"]
+
+
+@pytest.mark.L1
+def test_compare_reports_keys_present_on_only_one_side():
+    """A list that changed length must not be silently diffed against itself."""
+    diff = compare({"0:verbatim": True}, {"0:verbatim": True, "1:verbatim": True})
+
+    assert diff["only_in_after"] == ["1:verbatim"]
+    assert diff["lost"] == []
+
+
+@pytest.mark.L1
+def test_compare_mode_exits_non_zero_when_something_was_lost(tmp_path, capsys):
+    """CI can gate on it: a lost spelling is a failing exit code."""
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    before.write_text(json.dumps({"results": {"0:spaced": True}}))
+    after.write_text(json.dumps({"results": {"0:spaced": False}}))
+
+    assert main(["--compare", str(before), str(after)]) == 1
+    assert "0:spaced" in capsys.readouterr().out
+
+
+@pytest.mark.L1
+def test_compare_mode_exits_zero_when_nothing_was_lost(tmp_path):
+    before = tmp_path / "before.json"
+    after = tmp_path / "after.json"
+    before.write_text(json.dumps({"results": {"0:spaced": True}}))
+    after.write_text(json.dumps({"results": {"0:spaced": True, "1:spaced": True}}))
+
+    assert main(["--compare", str(before), str(after)]) == 0
+
+
+@pytest.mark.L1
+def test_sweep_over_a_synthetic_list_runs_the_deployed_path(tmp_path):
+    """End to end on a small list, so the machinery is exercised without a checkpoint."""
+    blocklist_dir = tmp_path / "custom"
+    blocklist_dir.mkdir()
+    (blocklist_dir / "list").write_text("deskin\n", encoding="utf-8")
+
+    assert main([str(blocklist_dir), "--json", str(tmp_path / "out.json")]) == 0
+
+    written = json.loads((tmp_path / "out.json").read_text())
+    assert written["results"]["0:verbatim"] is True
+    assert written["summary"]["total"]["blocked"] >= 1


### PR DESCRIPTION
A corpus of ordinary model output answers one question: does a change block things it did not block before. Any change that *unblocks* — a whitelist entry, moving an entry between lists, a new exemption mechanism — carries the opposite risk, and a corpus cannot show it. The phrasings that would newly slip through are exactly the ones ordinary output does not contain.

This adds the missing side, as a tool rather than a one-off script, so the next change of that kind can show what it gave up without a reviewer having to ask for it.

## What it does

For every blocklist entry it writes four prompts, one per way the entry can be spelled while still reading as itself:

| spelling | example for `deskin` |
|---|---|
| `verbatim` | `a photo of deskin in the scene` |
| `spaced` | `a photo of des kin in the scene` |
| `invisible` | `des` + U+200B + `kin` |
| `fullwidth` | `a photo of ｄｅｓｋｉｎ in the scene` |

Run it before and after a change and diff the two result files. Anything blocked before and not after is a spelling the change gave up. `--compare` exits non-zero when that set is non-empty, so a change can be gated on it.

```bash
coverage.py <ckpt>/blocklist/custom --whitelist-dir <ckpt>/blocklist/whitelist --json before.json
coverage.py <ckpt>/blocklist/custom --whitelist-dir <ckpt>/blocklist/whitelist --add-phrase "desk in" --json after.json
coverage.py --compare before.json after.json
```

Entry text never appears in the output — results are keyed by entry index and spelling — so the numbers can be pasted into a review or a ticket without reproducing content-safety terms.

## Against the shipped list

383 entries, 1532 prompts:

```
verbatim   blocked 382   passed  1
spaced     blocked 334   passed 49
invisible  blocked 334   passed 49
fullwidth  blocked 382   passed  1
total      blocked 1432  passed 100
```

Two things worth noting from that run, neither caused by this PR:

- one entry does not block a sentence containing its own text, so it protects nothing at all;
- 49 entries can still be split with a space or a zero-width character.

Both are list-level observations for the owners, not changes proposed here.

## Notes

`--add-phrase` models whitelisting a phrase. On `main` today that is a no-op — the matcher's whitelist only holds single tokens, so a phrase never reaches it — and the tool correctly reports no change. It becomes meaningful with #186, which adds phrase support. The tool measures whatever the tree does; it does not assume either outcome.

## Testing

`coverage_test.py`: 9 tests, all on synthetic lists, no checkpoint required — spelling generation including the short-entry edge case, index-and-spelling keying, per-spelling summarisation, the before/after diff, keys present on only one side, both `--compare` exit codes, and one end-to-end sweep over a one-entry list.

Full guardrail suite: 41 passed.