### PR TITLE
fix(inference): drop 1080 from the advertised resolutions

### DIFF
--- a/cosmos_framework/inference/args.py
+++ b/cosmos_framework/inference/args.py
@@ -128,9 +128,9 @@ class SamplingOverrides(OverridesBase):
             self.num_steps = min(self.num_steps, 1)
 
 
-InferenceResolution = Literal["256", "480", "720", "768", "1080"]
+InferenceResolution = Literal["256", "480", "720", "768"]
 if TRAINING:
-    Resolution = Literal["256", "480", "704", "720", "768", "1080"]
+    Resolution = Literal["256", "480", "704", "720", "768"]
 else:
     Resolution = InferenceResolution
 AspectRatio = Literal["1,1", "4,3", "3,4", "16,9", "9,16"]
@@ -452,8 +452,19 @@ class VisionDataOverrides(OverridesBase, _VisionDataBase):
     # Vision fields
     resolution: Resolution | None = None
     """Vision resolution.
-    
+
     Defaults to model config resolution.
+
+    Accepting a value here does not mean the loaded checkpoint can generate it.
+    Per the published model cards:
+
+    * Cosmos3-Edge: 256/480, images and video.
+    * Cosmos3-Nano: 256/480/720, images and video.
+    * Cosmos3-Super: 256/480/720; 768 additionally for images (the shipped tier
+      of the Super-Text2Image variants).
+
+    These ranges are not enforced per checkpoint: a value outside them still
+    runs, at a tier the model was never trained on.
     """
     aspect_ratio: AspectRatio | None = None
     """Vision aspect ratio. When None, image_edit preserves the input image's native
@@ -464,7 +475,8 @@ class VisionDataOverrides(OverridesBase, _VisionDataBase):
     """Number of vision frames.
 
     Range by resolution: 256p: [24, 400], 480p: [24, 300], 720p/768p: [24, 200].
-    Image-only resolutions (e.g. 1080p) require num_frames=1.
+    These are global limits; a checkpoint's own published range may be tighter
+    (Cosmos3-Edge is documented as 50-150 video frames).
     """
     video_save_quality: Training[VideoSaveQuality | None] = None
     """Quality of the saved video (0-10)."""


### PR DESCRIPTION
## Problem

`1080` was listed as a selectable `resolution` on every surface a user checks, but no published checkpoint can generate at that tier:

- the exported parameter schema (`OmniSampleOverrides.schema.json`)
- the tyro `--resolution {...}` choice list
- the `Input should be ...` error raised for an unsupported value

Reported from a QA parameter sweep (100% repro):

```
-i .../t2v_param_test/1000_9.json --checkpoint-path Cosmos3-Edge   # {"resolution": "1080"}

ValueError: Resolution '1080' only supports image generation (num_frames=1).
For video, use one of: ['256', '480', '704', '720', '768']
```

Two problems with that outcome:

1. **It arrived late.** The check lives in `_build_vision_data`, which runs after the guardrail + checkpoint + VAE downloads and after the model is built — about a minute of work before the user learns the value is unusable.
2. **The message was wrong.** No model card (Edge, Nano, Super, Experimental) lists 1080 for video *or* images. Following the suggestion and rerunning with `num_frames=1` did not error — it silently produced a 1440x1440 image from a tier the model was never trained on, at the same `shift` used for 480p.

For reference, the Cosmos3-Edge card states:

> Video generation supports 256p and 480p resolution, 12-30 fps, and 50-150 frames.

## Change

Remove `1080` from both `Resolution` tiers, so it is rejected at input-file parse time before any download:

```
Input should be '256', '480', '704', '720' or '768' [type=literal_error, input_value='1080']
```

Training does not need the value either: the `gt1080p` dataset bucket resolves through `_DATASET_RESOLUTION_TIER` into `IMAGE_RES_SIZE_INFO` / `VIDEO_RES_SIZE_INFO`, which are keyed by plain `str` and never consult this Literal.

Also documents the per-model ranges on the `resolution` field so the exported parameter file says what each checkpoint actually supports, and drops the now-false `Image-only resolutions (e.g. 1080p) require num_frames=1` line from `num_frames`.

## Verification

Exported parameter schema, before → after:

```
resolution   256/480/720/768/1080   →   resolution   256/480/720/768
```

Running the original repro command now fails immediately with **zero** download/model-construction log lines.

`args_test.py`, `dataset_samples_test.py`, `local_first_test.py`: 41 passed. The 2 failures in `test_distilled_checkpoint_uses_published_fixed_step_schedule[Cosmos3-Super-*-4Step]` are pre-existing on this machine (they require `WORLD_SIZE >= 4`) and fail identically without this change.

## Note for downstream QA

Any `text2image` case at 1080 currently marked expected-pass will now fail. That is the intended outcome — those runs were producing untrained-tier output silently — but expected results need updating.

## Not covered here

Related gaps, tracked separately, that do **not** error today:

- Edge accepts 720p/768p despite the card capping it at 480p.
- `num_frames` is validated against global limits (24-300) rather than Edge's documented 50-150.
- `704` remains selectable and is not a supported tier for any published checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)