### PR TITLE
Add guidance interval to RoboLab policy server

### DIFF
--- a/cosmos_framework/scripts/action_policy_server_robolab.py
+++ b/cosmos_framework/scripts/action_policy_server_robolab.py
@@ -49,7 +49,7 @@ from cosmos_framework.data.generator.action.utils.pose_utils import (
 )
 from cosmos_framework.data.generator.action.utils.transforms import ActionTransformPipeline
 from cosmos_framework.data.generator.joint_dataloader import IterativeJointDataLoader
-from cosmos_framework.inference.args import OmniSetupArgs, OmniSetupOverrides
+from cosmos_framework.inference.args import GuidanceInterval, OmniSetupArgs, OmniSetupOverrides
 from cosmos_framework.inference.common.args import ConfigFileType, ConfigOverrides, tyro_cli
 from cosmos_framework.inference.common.config import deserialize_config, deserialize_config_dict, load_config
 from cosmos_framework.inference.common.init import init_output_dir
@@ -285,6 +285,7 @@ class RobolabPolicyConfig:
     seed: int
     deterministic_seed: bool
     guidance: float
+    guidance_interval: GuidanceInterval | None
     num_steps: int
     shift: float
     conditioning_fps: float
@@ -334,6 +335,8 @@ class RobolabServerArgs(pydantic.BaseModel):
     """Use the same seed for every request. If false, advance a NumPy RNG seeded by --seed."""
     guidance: float = 3.0
     """Guidance scale for denoising."""
+    guidance_interval: GuidanceInterval | None = None
+    """Optional inclusive timestep interval [low, high] in which to apply classifier-free guidance."""
     num_steps: int = 4
     """Number of denoising steps."""
     shift: float = 5.0
@@ -391,6 +394,7 @@ class RobolabPolicyService:
             seed=int(args.seed),
             deterministic_seed=bool(args.deterministic_seed),
             guidance=float(args.guidance),
+            guidance_interval=args.guidance_interval,
             num_steps=int(args.num_steps),
             shift=float(args.shift),
             conditioning_fps=float(
@@ -419,7 +423,8 @@ class RobolabPolicyService:
             f"action_space={self.cfg.action_space} action_dim={self.cfg.action_dim} "
             f"chunk={self.cfg.action_chunk_size} history={self.cfg.history_length} use_state={self.cfg.use_state} "
             f"image={self.cfg.image_height}x{self.cfg.image_width} fps={self.cfg.conditioning_fps} "
-            f"guidance={self.cfg.guidance} num_steps={self.cfg.num_steps} shift={self.cfg.shift} "
+            f"guidance={self.cfg.guidance} guidance_interval={self.cfg.guidance_interval} "
+            f"num_steps={self.cfg.num_steps} shift={self.cfg.shift} "
             f"seed={self.cfg.seed} deterministic_seed={self.cfg.deterministic_seed}"
         )
 
@@ -587,6 +592,9 @@ class RobolabPolicyService:
                 samples = self.model.generate_samples_from_batch(
                     data_batch,
                     guidance=self.cfg.guidance,
+                    guidance_interval=(
+                        list(self.cfg.guidance_interval) if self.cfg.guidance_interval is not None else None
+                    ),
                     seed=[seed],
                     num_steps=self.cfg.num_steps,
                     shift=self.cfg.shift,

--- a/cosmos_framework/scripts/action_policy_server_robolab_test.py
+++ b/cosmos_framework/scripts/action_policy_server_robolab_test.py
@@ -91,9 +91,16 @@ def test_server_args_default_to_released_droid_serving_config() -> None:
     assert args.action_space == "joint_pos"
     assert args.use_state is True
     assert args.guidance == 3.0
+    assert args.guidance_interval is None
     assert args.num_steps == 4
     assert args.shift == 5.0
     assert args.deterministic_seed is False
+
+
+def test_server_args_accept_guidance_interval() -> None:
+    args = robolab_server.RobolabServerArgs(guidance_interval=(960.0, 1001.0))
+
+    assert args.guidance_interval == (960.0, 1001.0)
 
 
 def test_joint_pos_observation_preprocessing_matches_internal_layout() -> None:
@@ -105,6 +112,7 @@ def test_joint_pos_observation_preprocessing_matches_internal_layout() -> None:
         seed=0,
         deterministic_seed=True,
         guidance=3.0,
+        guidance_interval=None,
         num_steps=4,
         shift=5.0,
         conditioning_fps=15.0,

--- a/docs/action_policy_droid_server.md
+++ b/docs/action_policy_droid_server.md
@@ -79,8 +79,13 @@ Inside the container, start the policy server:
    python -m cosmos_framework.scripts.action_policy_server_robolab \
      --checkpoint-path nvidia/Cosmos3-Edge-Policy-DROID \
      --port 8000 \
-     --format-prompt-as-json True
+     --format-prompt-as-json True \
+     --guidance-interval 960 1001
    ```
+
+   The guidance interval applies classifier-free guidance only to denoising
+   timesteps in the inclusive range `[960, 1001]`. Omit
+   `--guidance-interval` to apply guidance at every denoising step.
 
 ## Simulation Client
 


### PR DESCRIPTION
## Summary
- expose an optional classifier-free guidance timestep interval in the RoboLab policy server
- forward and log the interval while preserving full-step guidance as the default
- update the Edge DROID launch instructions to use first-step-only guidance over `[960, 1001]`

## Test plan
- [x] `git diff --check`
- [x] IDE lint diagnostics
- [ ] `uv run --no-sync pytest cosmos_framework/scripts/action_policy_server_robolab_test.py -q` (fresh checkout is missing `omegaconf`; test collection could not start)