### PR TITLE
docs(inference): document resolution as a tier, not a pixel height

### DIFF
--- a/cosmos_framework/inference/args.py
+++ b/cosmos_framework/inference/args.py
@@ -451,7 +451,9 @@ class VisionDataOverrides(OverridesBase, _VisionDataBase):
 
     # Vision fields
     resolution: Resolution | None = None
-    """Vision resolution.
+    """Vision resolution tier, not a pixel dimension. Resolved against
+    ``aspect_ratio`` by ``vision_size`` -- ``"256"`` at the default ``16,9``
+    yields 320x192. See docs/inference.md for the full table.
 
     Defaults to model config resolution.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -200,6 +200,18 @@ Depends on resolution:
 
 Default is 189 frames at 24 FPS (~7.9 seconds).
 
+### Q: I set `resolution` to `256` but the output is 320x192 — why?
+
+`resolution` names a resolution *tier*, not the output height. The actual width and height
+are looked up from the tier together with `aspect_ratio`, which defaults to `16,9`.
+
+The `256` tier is the one where the two disagree: `"256"` + `16,9` resolves to 320x192.
+Within the same tier, `1,1` gives 256x256 and `4,3` gives 320x256, so set `aspect_ratio`
+explicitly if you need a 256-pixel short edge. The `480` and `720` tiers do not have this
+mismatch — their `16,9` entries are 832x480 and 1280x720.
+
+See [Inference § Resolution tiers](./inference.md#resolution-tiers) for the full table.
+
 ### Q: What input formats does image-to-video support?
 
 Provide a `vision_path` pointing to an image (`.jpg`, `.jpeg`, `.png`) or a URL. See `inputs/omni/i2v.json` for the format.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -20,6 +20,7 @@ ______________________________________________________________________
 - [Sample Arguments](#sample-arguments)
   - [Text](#text)
   - [Vision (Image/Video)](#vision-imagevideo)
+    - [Resolution tiers](#resolution-tiers)
   - [Action](#action)
   - [Reasoner](#reasoner)
   - [Custom Defaults](#custom-defaults)
@@ -221,13 +222,13 @@ For the `480` and `720` tiers the `16,9` output height matches the tier name (`8
 `1280x720`). The `256` tier does not: its widescreen entries are smaller than the name
 suggests.
 
-| `aspect_ratio` | `256` | `480` | `720` | `768` |
-| -------------- | ----- | ----- | ----- | ----- |
-| `1,1`  | 256x256 | 640x640 | 960x960 | 1024x1024 |
-| `4,3`  | 320x256 | 736x544 | 1104x832 | 1184x880 |
-| `3,4`  | 256x320 | 544x736 | 832x1104 | 880x1184 |
-| `16,9` | **320x192** | 832x480 | 1280x720 | 1360x768 |
-| `9,16` | **192x320** | 480x832 | 720x1280 | 768x1360 |
+| `aspect_ratio` | `256`       | `480`   | `720`    | `768`     |
+| -------------- | ----------- | ------- | -------- | --------- |
+| `1,1`          | 256x256     | 640x640 | 960x960  | 1024x1024 |
+| `4,3`          | 320x256     | 736x544 | 1104x832 | 1184x880  |
+| `3,4`          | 256x320     | 544x736 | 832x1104 | 880x1184  |
+| `16,9`         | **320x192** | 832x480 | 1280x720 | 1360x768  |
+| `9,16`         | **192x320** | 480x832 | 720x1280 | 768x1360  |
 
 So `resolution: "256"` with the default `16,9` produces a 320x192 output, not 256 pixels
 tall. Use `aspect_ratio: "1,1"` or `"4,3"` if you need a 256-pixel short edge at that tier.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -210,8 +210,29 @@ Common arguments:
 Common arguments:
 
 - `fps`: Condition and output frames per second.
-- `resolution` (`"256"`, `"480"`, `"720"`): Condition and output resolution (height in pixels).
-- `aspect_ratio` (`1,1`, `4,3`, `"3,4`, `16,9`, `9,16`): Condition and output aspect ratio. Defaults to `16,9`.
+- `resolution` (`"256"`, `"480"`, `"720"`, `"768"`): Condition and output resolution **tier**, not a
+  pixel dimension. The output width and height are looked up from the tier *and* the
+  aspect ratio — see [Resolution tiers](#resolution-tiers) below.
+- `aspect_ratio` (`1,1`, `4,3`, `3,4`, `16,9`, `9,16`): Condition and output aspect ratio. Defaults to `16,9`.
+
+#### Resolution tiers
+
+For the `480` and `720` tiers the `16,9` output height matches the tier name (`832x480`,
+`1280x720`). The `256` tier does not: its widescreen entries are smaller than the name
+suggests.
+
+| `aspect_ratio` | `256` | `480` | `720` | `768` |
+| -------------- | ----- | ----- | ----- | ----- |
+| `1,1`  | 256x256 | 640x640 | 960x960 | 1024x1024 |
+| `4,3`  | 320x256 | 736x544 | 1104x832 | 1184x880 |
+| `3,4`  | 256x320 | 544x736 | 832x1104 | 880x1184 |
+| `16,9` | **320x192** | 832x480 | 1280x720 | 1360x768 |
+| `9,16` | **192x320** | 480x832 | 720x1280 | 768x1360 |
+
+So `resolution: "256"` with the default `16,9` produces a 320x192 output, not 256 pixels
+tall. Use `aspect_ratio: "1,1"` or `"4,3"` if you need a 256-pixel short edge at that tier.
+The authoritative tables are `IMAGE_RES_SIZE_INFO` and `VIDEO_RES_SIZE_INFO` in
+`cosmos_framework/data/generator/utils.py`.
 
 Condition arguments:
 


### PR DESCRIPTION
## Problem

`docs/inference.md` documented the `resolution` argument as:

> `resolution` (`"256"`, `"480"`, `"720"`): Condition and output resolution (height in pixels).

That is not what it does. `resolution` selects a *tier*; the output width and height are looked up from the tier together with `aspect_ratio` in `IMAGE_RES_SIZE_INFO` / `VIDEO_RES_SIZE_INFO` (`cosmos_framework/data/generator/utils.py`), via `OmniSampleArgs.vision_size`.

For the `480` and `720` tiers the `16,9` height happens to equal the tier name (832x480, 1280x720), so the old wording held up in practice. The `256` tier is the exception:

```python
"256": {"1,1": (256,256), "4,3": (320,256), "3,4": (256,320),
        "16,9": (320, 192), "9,16": (192, 320)}    # (W, H)
```

So `resolution: "256"` with the default `aspect_ratio: "16,9"` produces **320x192**, not a 256-pixel-tall output. This was filed as nvbug 6439536 against V2V/I2V/T2V on Nano/Super/Edge — one root cause, since all modalities and checkpoints read the same global table with no per-model override.

## Changes

- `docs/inference.md` — replace the "(height in pixels)" description with the tier semantics, and add a `#### Resolution tiers` section with the full tier x aspect-ratio table for the four advertised tiers.
- `docs/faq.md` — add `Q: I set resolution to 256 but the output is 320x192 — why?`, placed next to the existing frames-per-resolution entry and linking to the new section.
- `cosmos_framework/inference/args.py` — correct the `resolution` docstring (3 lines; details live in the docs).

Drive-by, both on the same line as the main fix:

- add `"768"` to the documented `resolution` values — it is in `InferenceResolution` but was missing from the docs;
- drop a stray quote in the `aspect_ratio` value list (`` `"3,4` `` → `` `3,4` ``).

## Notes

No behavior change — documentation and one docstring only.

Whether the `256` tier itself should be re-sized is a separate, model-side question. `data/generator/utils.py:43` carries a long-standing note that the intended values are `"16,9": (448, 256)`; changing them would alter training-time bucketing (`model/generator/omni_mot_model.py:3922`, `model/generator/tokenizers/wan2pt2_vae_4x16x16.py:1297`) and require re-validating Nano, Super and Edge. This PR only makes the current behavior discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)