### PR TITLE
fix(utils): call maybe_download_hf_model_from_s3 in downloader __main__ blocks

### DIFF
--- a/cosmos_framework/utils/generator/reasoner/pretrained_models_downloader.py
+++ b/cosmos_framework/utils/generator/reasoner/pretrained_models_downloader.py
@@ -349,7 +349,7 @@ if __name__ == "__main__":
     Usage:
     PYTHONPATH=. python3 cosmos_framework/utils/reasoner/pretrained_models_downloader.py
     """
-    cache_dir = maybe_download_model(  # noqa: F821
+    cache_dir = maybe_download_hf_model_from_s3(
         "eagle_er_qwen3_1p7b_siglip_400m", "credentials/s3_training.secret", "bucket4"
     )
     print(f"Downloaded to {cache_dir}")

--- a/cosmos_framework/utils/reasoner/pretrained_models_downloader.py
+++ b/cosmos_framework/utils/reasoner/pretrained_models_downloader.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
     Usage:
     PYTHONPATH=. python3 cosmos_framework/utils/reasoner/pretrained_models_downloader.py
     """
-    cache_dir = maybe_download_model(  # noqa: F821
+    cache_dir = maybe_download_hf_model_from_s3(
         "eagle_er_qwen3_1p7b_siglip_400m", "credentials/s3_training.secret", "bucket4"
     )
     print(f"Downloaded to {cache_dir}")


### PR DESCRIPTION
## Summary

Both `cosmos_framework/utils/reasoner/pretrained_models_downloader.py` and `cosmos_framework/utils/generator/reasoner/pretrained_models_downloader.py` expose a `__main__` block whose docstring documents running the file directly (`PYTHONPATH=. python3 cosmos_framework/utils/reasoner/pretrained_models_downloader.py`). That block calls `maybe_download_model(...)`, but no such name is defined or imported in either file — the real entry point is `maybe_download_hf_model_from_s3`. Executing the documented command therefore crashes immediately with `NameError: name 'maybe_download_model' is not defined`.

## Fix

Rename the `__main__` call to `maybe_download_hf_model_from_s3` in both files (signature `(model_name_or_path, credentials, bucket)`, matching the call site) and remove the now-redundant `# noqa: F821` suppression.

## Verification

- `pyflakes` no longer reports `undefined name 'maybe_download_model'` (F821) for either file.
- AST-level check confirms `maybe_download_hf_model_from_s3` is defined in each module and that the `__main__` block now references it.

No behavior change for library callers; only the standalone-script entry point is repaired.