### PR TITLE
fix(video): only send output_dtype to TorchCodec when it is not the default

### DIFF
--- a/cosmos_framework/utils/generator/torchcodec_video.py
+++ b/cosmos_framework/utils/generator/torchcodec_video.py
@@ -12,6 +12,7 @@ from typing import Any, BinaryIO
 
 import numpy as np
 import torch
+import torchcodec
 from torchcodec.decoders import VideoDecoder
 from torchcodec.transforms import Resize
 
@@ -24,6 +25,10 @@ class VideoMetadata:
     average_fps: float
     height: int | None = None
     width: int | None = None
+
+
+def _torchcodec_version() -> str:
+    return getattr(torchcodec, "__version__", "(unknown version)")
 
 
 def _normalize_source(source: VideoSource) -> VideoSource:
@@ -47,16 +52,32 @@ def _build_decoder(
     normalized_source = _normalize_source(source)
     # Preserve FFmpeg/TorchCodec's 0 sentinel so callers can request automatic thread selection.
     num_ffmpeg_threads = 0 if num_threads == 0 else max(num_threads, 1)
-    kwargs: dict[str, Any] = {"num_ffmpeg_threads": num_ffmpeg_threads, "output_dtype": output_dtype}
+    kwargs: dict[str, Any] = {"num_ffmpeg_threads": num_ffmpeg_threads}
     if custom_frame_mappings is None:
         kwargs["seek_mode"] = seek_mode
     else:
         kwargs["custom_frame_mappings"] = custom_frame_mappings
     if device != "cpu":
         kwargs["device"] = device
+    # ``output_dtype`` arrived after the pinned cu128/cu130 TorchCodec (0.10.0), whose
+    # ``VideoDecoder.__init__`` has no such parameter -- forwarding it unconditionally breaks
+    # every call, including plain metadata probes.  uint8 is 0.10's native output, so only a
+    # non-default request needs the keyword at all.  (``transforms`` does exist on 0.10; it is
+    # still sent only on demand, and covered by the same guard for older builds.)
+    if output_dtype != torch.uint8:
+        kwargs["output_dtype"] = output_dtype
     if resize_size is not None:
         kwargs["transforms"] = [Resize(resize_size)]
-    return VideoDecoder(normalized_source, **kwargs)
+    try:
+        return VideoDecoder(normalized_source, **kwargs)
+    except TypeError as error:
+        unsupported = next((key for key in ("output_dtype", "transforms") if key in kwargs and key in str(error)), None)
+        if unsupported is None:
+            raise
+        raise TypeError(
+            f"Installed torchcodec {_torchcodec_version()} does not support VideoDecoder({unsupported}=...). "
+            f"Upgrade torchcodec to use {unsupported}."
+        ) from error
 
 
 def _read_basic_metadata(decoder: Any) -> tuple[int, float]:


### PR DESCRIPTION
## What

Fixes the `generator-inference-smoke` failure on #231.

`_build_decoder` forwards `output_dtype=torch.uint8` into `VideoDecoder(...)` on **every** call:

```python
kwargs: dict[str, Any] = {"num_ffmpeg_threads": num_ffmpeg_threads, "output_dtype": output_dtype}
```

`output_dtype` does not exist on the pinned TorchCodec. `pyproject.toml` resolves `cu128` and `cu130` to `torchcodec==0.10.0`, whose `VideoDecoder.__init__` is:

```python
def __init__(self, source, *, stream_index=None, dimension_order="NCHW",
             num_ffmpeg_threads=1, device=None, seek_mode="exact",
             transforms=None, custom_frame_mappings=None):
```

Only the `cu130-torch213` group pins a release new enough (`0.14.0`). Every CI job runs `--group=cu128-train`, so every decoder construction — including plain metadata probes via `probe_video()` — raised:

```
TypeError: VideoDecoder.__init__() got an unexpected keyword argument 'output_dtype'
```

uint8 is already 0.10's native output, so the default carried no information and only broke the call.

## Why the failure was so expensive to read

In `test_nano_inference_omni` it was **rank 1** that raised. The other three ranks carried on into an `ALLREDUCE` and sat there until the 1800s NCCL watchdog fired, at which point `ProcessGroupNCCL` took them down with `SIGABRT` (exitcode `-6`, `traceback: NoneType: None`). 30 of the job's 36 minutes were the timeout, and the real one-line `TypeError` was ~950 lines above the reported failure.

The same bug in `test_nano_inference_multi_control_transfer` hit **rank 0** and failed cleanly in ~14 seconds — same root cause, completely different-looking failure, decided purely by which rank got there first.

## The fix

- Send `output_dtype` only when it differs from the `uint8` default, restoring the default path to its pre-regression behaviour.
- Translate a rejected `output_dtype` / `transforms` keyword into a message naming the knob and the installed version, so a genuine request on an old build fails legibly instead of as a bare `TypeError` deep inside a rank.

No caller anywhere in the repo passes `output_dtype` or `resize_size`, so nothing loses functionality. `transforms` **does** exist on 0.10.0 and is unaffected; it is covered by the same guard for older builds.

`interleaved_video_parsing.py` already carries this exact defensive pattern (`_SUPPORTS_VIDEO_DECODER_OUTPUT_DTYPE`, the cached `TypeError` probe). It just was not applied to `torchcodec_video.py`.

## Tests

`torchcodec_video.py` had **no test file at all** — which is why a pure-Python signature mismatch had to be caught by a 4-GPU inference smoke test instead of a unit test.

Adds `torchcodec_video_test.py` (6 tests). The decoders in it mirror the real 0.10.0 and newer signatures rather than whatever CI resolved, so the behaviour is pinned on both. Verified red→green: the 3 compatibility tests fail against the current code with the exact production error (`torchcodec_video.py:59`) and pass after the fix. `ruff check` and `ruff format --check` are clean on both files.

## Base

Targets `release/2026-09-03-3f2febdb` so #231 can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
