### PR TITLE
docs: add Feature Request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,11 +12,7 @@ labels: 'enhancement'
 
 ## Proposed Feature
 
-<!-- What feature/capability would you like to have? -->
-
-## Alternatives Considered
-
-<!-- Workarounds you've tried -->
+<!-- What feature or improvement would you like to have? -->
 
 ## Affected Area
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: "[FEAT] <short description>"
+labels: 'enhancement'
+
+---
+
+## Problem/Use Case
+
+<!-- What would you like to accomplish? -->
+
+## Proposed Feature
+
+<!-- What feature/capability would you like to have? -->
+
+## Alternatives Considered
+
+<!-- Workarounds you've tried -->
+
+## Affected Area
+
+- [ ] Inference
+- [ ] Training / post-training
+- [ ] Data / datasets
+- [ ] Models
+- [ ] Docs / examples
+- [ ] Other
+
+## Additional Context
+
+<!-- Papers, links, related issues -->


### PR DESCRIPTION
Adds a Feature Request option to the new-issue chooser, between Bug Report and Blank issue.

Template sections: 
* Problem/Use Case
* Proposed Feature
* Affected Area
* Additional Context

Follows `bug_report.md` conventions: markdown + frontmatter rather than a YAML form, `[FEAT]` title prefix, existing `enhancement` label. 

No assignee by default, so these go through normal triage.
