### PR TITLE
fix(inference): keep the diffusion cache off for quantized inference

### DIFF
--- a/cosmos_framework/inference/common/args.py
+++ b/cosmos_framework/inference/common/args.py
@@ -956,7 +956,8 @@ class SetupOverrides(ABC, CheckpointOverrides, ParallelismOverrides, Quantizatio
     it by default; pass ``--no-diffusion-cache`` to disable it. Caching is based on
     SeaCache: Spectral-Evolution-Aware Cache for Accelerating Diffusion Models
     (https://arxiv.org/abs/2602.18993). Autoregressive and KV-cache generation
-    bypass the cache automatically.
+    bypass the cache automatically. Quantized inference (ModelOpt FP8 checkpoints,
+    ``--quantization-method`` mxfp8/nvfp4) keeps the cache off and logs a warning.
     """
     diffusion_cache_thresh: float | None = None
     """Accumulated relative-L1 threshold (``diffusion_cache_thresh``), shared by the

--- a/cosmos_framework/inference/inference.py
+++ b/cosmos_framework/inference/inference.py
@@ -58,6 +58,7 @@ from cosmos_framework.model.generator.upsampler.prompts import is_upsampled_prom
 from cosmos_framework.tools.visualize.video import save_img_or_video
 from cosmos_framework.utils import log
 from cosmos_framework.utils.checkpoint_db import CheckpointDirHf
+from cosmos_framework.utils.generator.quantization import collect_modelopt_fp8_params
 
 if TYPE_CHECKING:
     from cosmos_framework.configs.base.defaults.model_config import OmniMoTModelConfig
@@ -1131,6 +1132,23 @@ class SampleDataset(Dataset):
         return sample_args, data_batch
 
 
+def _quantized_inference_kind(pipe: Any, setup_args: SetupArgs) -> str | None:
+    """Return what makes this run quantized for the diffusion-cache policy, or ``None``.
+
+    Runtime PTQ (``--quantization-method``) is read from the setup args. ModelOpt
+    FP8 checkpoints are recognized from the loaded network rather than from the
+    ``checkpoint_path`` string: by now the loader has swapped the quantized linears
+    to ``_ModelOptFloat8Linear``, so registry names, local directories and DCP
+    paths all resolve the same way.
+    """
+    if setup_args.quantization_method is not None:
+        return str(setup_args.quantization_method)
+    model = getattr(pipe, "model", None)
+    if isinstance(model, torch.nn.Module) and collect_modelopt_fp8_params(model):
+        return "modelopt-fp8"
+    return None
+
+
 @dataclass
 class OmniInference(Inference):
     # pyrefly: ignore[bad-override]
@@ -1354,9 +1372,23 @@ class OmniInference(Inference):
     def _maybe_install_diffusion_cache(pipe: "OmniInference", setup_args: SetupArgs) -> None:
         """Install SeaCache on ``pipe.model`` when ``setup_args.diffusion_cache`` is set.
 
+        Quantized inference (ModelOpt FP8 checkpoints, mxfp8/nvfp4 runtime PTQ) keeps
+        the cache off and logs a warning: SeaCache extrapolates the language_model
+        residual across skipped steps from the difference of the last full evaluations,
+        and W8A8 activation quantization adds input-dependent noise of the same order
+        as that difference, which shows up as frame-to-frame flicker. Weight-only
+        error (BF16, W8A16) is smooth in the input and cancels in the difference.
+
         ``num_steps`` is adopted per ``generate_samples_from_batch`` call via
         ``begin_generation``, so install-time ``sample_args_list`` can be empty.
         """
+        quantization = _quantized_inference_kind(pipe, setup_args)
+        if quantization is not None:
+            log.warning(
+                f"Diffusion cache is disabled for quantized inference ({quantization}): SeaCache residual "
+                "extrapolation amplifies activation-quantization noise into visible flicker."
+            )
+            return
         if not setup_args.diffusion_cache:
             return
         from cosmos_framework.model.generator.mot.diffusion_cache import install_diffusion_cache

--- a/cosmos_framework/inference/inference_test.py
+++ b/cosmos_framework/inference/inference_test.py
@@ -10,19 +10,49 @@ from unittest.mock import Mock
 import pytest
 
 
-def test_diffusion_cache_max_consecutive_cached_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def _diffusion_cache_setup_args(**overrides: Any) -> SimpleNamespace:
+    fields: dict[str, Any] = dict(
+        diffusion_cache=True,
+        diffusion_cache_thresh=None,
+        diffusion_cache_residual_order=None,
+        diffusion_cache_max_consecutive_cached=None,
+        quantization_method=None,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def _bf16_model() -> Any:
+    torch = pytest.importorskip("torch")
+    return torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 4))
+
+
+def _modelopt_fp8_model() -> Any:
+    torch = pytest.importorskip("torch")
+    from cosmos_framework.utils.generator.quantization import _ModelOptFloat8Linear
+
+    # The loader swaps ModelOpt FP8 targets to this module type; its presence is
+    # what marks a loaded model as W8A8-quantized.
+    return torch.nn.Sequential(torch.nn.Linear(4, 4), _ModelOptFloat8Linear(4, 4, bias=False))
+
+
+def _patch_cache_install(monkeypatch: pytest.MonkeyPatch) -> tuple[Mock, Mock]:
     from cosmos_framework.inference import inference
     from cosmos_framework.model.generator.mot import diffusion_cache
 
     install = Mock()
+    warning = Mock()
     monkeypatch.setattr(diffusion_cache, "install_diffusion_cache", install)
-    pipe = SimpleNamespace()
-    setup_args = SimpleNamespace(
-        diffusion_cache=True,
-        diffusion_cache_thresh=None,
-        diffusion_cache_residual_order=None,
-        diffusion_cache_max_consecutive_cached=3,
-    )
+    monkeypatch.setattr(inference.log, "warning", warning)
+    return install, warning
+
+
+def test_diffusion_cache_max_consecutive_cached_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference import inference
+
+    install, _warning = _patch_cache_install(monkeypatch)
+    pipe = SimpleNamespace(model=_bf16_model())
+    setup_args = _diffusion_cache_setup_args(diffusion_cache_max_consecutive_cached=3)
 
     inference.OmniInference._maybe_install_diffusion_cache(pipe, setup_args)
 
@@ -32,6 +62,59 @@ def test_diffusion_cache_max_consecutive_cached_override(monkeypatch: pytest.Mon
         sample_args_list=[],
         config_overrides={"max_consecutive_cached": 3},
     )
+
+
+def test_diffusion_cache_is_disabled_by_default_for_modelopt_fp8_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference import inference
+
+    install, warning = _patch_cache_install(monkeypatch)
+    pipe = SimpleNamespace(model=_modelopt_fp8_model())
+
+    inference.OmniInference._maybe_install_diffusion_cache(pipe, _diffusion_cache_setup_args())
+
+    install.assert_not_called()
+    warning.assert_called_once()
+    assert "diffusion cache" in warning.call_args.args[0].lower()
+    assert "modelopt-fp8" in warning.call_args.args[0]
+
+
+def test_diffusion_cache_is_disabled_by_default_for_runtime_quantization(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference import inference
+
+    install, warning = _patch_cache_install(monkeypatch)
+    pipe = SimpleNamespace(model=_bf16_model())
+
+    inference.OmniInference._maybe_install_diffusion_cache(
+        pipe, _diffusion_cache_setup_args(quantization_method="nvfp4")
+    )
+
+    install.assert_not_called()
+    warning.assert_called_once()
+    assert "nvfp4" in warning.call_args.args[0]
+
+
+def test_diffusion_cache_warns_when_already_off_for_quantized_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference import inference
+
+    install, warning = _patch_cache_install(monkeypatch)
+    pipe = SimpleNamespace(model=_modelopt_fp8_model())
+
+    inference.OmniInference._maybe_install_diffusion_cache(pipe, _diffusion_cache_setup_args(diffusion_cache=False))
+
+    install.assert_not_called()
+    warning.assert_called_once()
+
+
+def test_diffusion_cache_unchanged_for_unquantized_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cosmos_framework.inference import inference
+
+    install, warning = _patch_cache_install(monkeypatch)
+    pipe = SimpleNamespace(model=_bf16_model())
+
+    inference.OmniInference._maybe_install_diffusion_cache(pipe, _diffusion_cache_setup_args())
+
+    install.assert_called_once_with(pipe=pipe, enabled=True, sample_args_list=[], config_overrides=None)
+    warning.assert_not_called()
 
 
 def test_finalize_data_batch_does_not_mutate_reusable_video_list() -> None:


### PR DESCRIPTION
## Summary

The inference CLI enables the SeaCache diffusion cache by default. On ModelOpt FP8 (W8A8) checkpoints this produces visible frame-to-frame flicker / softness, while the same checkpoint through NIM (`cache_backend=none`) and the framework with `--no-diffusion-cache` are clean. This is the framework-side issue reported in the Cosmos3 FP8 Slack thread (Carlos' Nano transfer/edge case).

Per the team decision (Liang Feng): quantized runs (FP8 / NVFP4) keep the cache **off**, bf16/fp16 keep the current default-on behavior, and a warning is logged whichever way the switch points.

## Root cause

The cache reconstructs skipped steps by extrapolating the `language_model` residual (`residual_order=1`) from the difference of the last two full evaluations (`model/generator/mot/diffusion_cache.py`). W8A8 activation quantization adds ~1.2 % input-dependent noise per forward, the same order as the ~2 % true step-to-step change, so the extrapolated residual is dominated by noise; the second consecutive skip (`max_consecutive_cached=2`) doubles it. Weight-only error (BF16, W8A16) is smooth in the input and cancels in the difference, which is why those paths are unaffected.

Measured on GB200, Nano transfer/edge 720p / 121 frames / 50 steps, seed 2026 (reference = BF16, no cache):

| config | frame-to-frame delta | PSNR vs BF16 no-cache |
|---|---|---|
| BF16, no cache | 1.34 | ref |
| FP8 W8A8, no cache | 1.52 | 30.6 dB |
| BF16, default cache | 1.48 | 32.3 dB |
| **FP8 W8A8, default cache** | **2.95** | **26.1 dB** |
| FP8 W8A8, cache, `residual_order=0` | 1.89 (blurry) | 25.2 dB |
| FP8 W8A8, cache, `residual_order=2` | 7.72 | 17.7 dB |
| FP8 W8A8, cache, `max_consecutive_cached=1` | 1.52 | 31.2 dB |
| FP8 all-W8A16 (mixed precision), default cache | clean | – |

Direct evidence at identical inputs: the step-to-step residual change is 1.8–3.2 % for BF16 and **identical** for W8A16, but 2.4–3.5 % for W8A8 and for dynamic per-tensor activation quantization. Skip decisions are identical between BF16 and FP8 (69 full / 81 skipped), so it is the reconstruction, not the decision, that breaks. `use_fast_accum`, `torch.compile`, static-scale saturation and dynamic activation quantization were all tested and ruled out.

## Change

One rule, applied where the cache is actually installed (`OmniInference._maybe_install_diffusion_cache`, so every caller — CLI, cosmos-benchmarks, Ray serve — and every checkpoint form — registry name, local dir, DCP — is covered, and the warning lands in the per-run logs):

- the run is quantized if `setup_args.quantization_method` is set (mxfp8 / nvfp4) or the loaded network contains ModelOpt FP8 linears (`collect_modelopt_fp8_params` non-empty);
- quantized ⇒ the cache is not installed and a `log.warning` names the reason, regardless of the switch;
- bf16/fp16 ⇒ unchanged.

Note: mixed-precision runs where every step is W8A16 are not affected by the bug but are still treated as quantized (conservative).

## Tests

- 4 new unit tests in `inference/inference_test.py` (cache off for a ModelOpt FP8 network, off for runtime PTQ, warning also when the switch is already off, bf16 unchanged). Written before the implementation and observed failing.
- `inference/inference_test.py`, `inference/args_test.py`, `inference/common/args_test.py`, `mot/diffusion_cache_test.py`: all pass except 3 environment-only failures (no CUDA on the login node, missing `uv`, missing `obstore`) that fail identically on `main`.
- ruff check clean.
- A GB200 end-to-end run of the branch (FP8 default must be bit-identical to the previous `--no-diffusion-cache` output; BF16 unchanged) is queued; I will post the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
